### PR TITLE
mux between provider servers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/hashicorp/go-memdb v1.2.1
-	github.com/hashicorp/terraform-plugin-go v0.0.0-20201007135710-95da7fbd4bb8
+	github.com/hashicorp/terraform-plugin-go v0.0.0-20201027121849-e227023a4d99
+	github.com/hashicorp/terraform-plugin-mux v0.0.0-20201027121817-adc4ce9f714b
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.0.4
 )

--- a/go.sum
+++ b/go.sum
@@ -187,9 +187,13 @@ github.com/hashicorp/terraform-exec v0.10.0 h1:3nh/1e3u9gYRUQGOKWp/8wPR7ABlL2F14
 github.com/hashicorp/terraform-exec v0.10.0/go.mod h1:tOT8j1J8rP05bZBGWXfMyU3HkLi1LWyqL3Bzsc3CJjo=
 github.com/hashicorp/terraform-json v0.5.0 h1:7TV3/F3y7QVSuN4r9BEXqnWqrAyeOtON8f0wvREtyzs=
 github.com/hashicorp/terraform-json v0.5.0/go.mod h1:eAbqb4w0pSlRmdvl8fOyHAi/+8jnkVYN28gJkSJrLhU=
-github.com/hashicorp/terraform-plugin-go v0.0.0-20201007135710-95da7fbd4bb8 h1:tR4P5qViPdGGzWwIvqm8ptQtYNhKqpkMPFoSG1VU5E0=
 github.com/hashicorp/terraform-plugin-go v0.0.0-20201007135710-95da7fbd4bb8/go.mod h1:iVxhkJdmLuDh+8BKTj9bdL+/lbusHKxAEuptE8VCjdM=
-github.com/hashicorp/terraform-plugin-sdk/v2 v2.0.4 h1:GYkUL3zjrZgig9Gm+/61+YglzESJxXRDMp7qhJsh4j0=
+github.com/hashicorp/terraform-plugin-go v0.0.0-20201020231029-49daeca5241c/go.mod h1:iVxhkJdmLuDh+8BKTj9bdL+/lbusHKxAEuptE8VCjdM=
+github.com/hashicorp/terraform-plugin-go v0.0.0-20201027121849-e227023a4d99 h1:HVNya2Bv6JXQlESotf/A/Lkv1W8U936v1uJ2ZxcuYXQ=
+github.com/hashicorp/terraform-plugin-go v0.0.0-20201027121849-e227023a4d99/go.mod h1:xbqx6szM1IDO6Y3SqIKkC4F667L9c1sP6fxU1I+o6NU=
+github.com/hashicorp/terraform-plugin-mux v0.0.0-20201008164311-144f92b1e360/go.mod h1:lKZXaUUhcUIwtLA2O1f29nc2cLateoTHQxvxTaKh0qU=
+github.com/hashicorp/terraform-plugin-mux v0.0.0-20201027121817-adc4ce9f714b h1:rSuKzWsF7k9fixKUfoJ8b6WB0+jAQX2uwMjWdSA9tj4=
+github.com/hashicorp/terraform-plugin-mux v0.0.0-20201027121817-adc4ce9f714b/go.mod h1:lKZXaUUhcUIwtLA2O1f29nc2cLateoTHQxvxTaKh0qU=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.0.4/go.mod h1:GP0lmw4Y+XV1OfTmi/hK75t5KWGGzoOzEgUBPGZ6Wq4=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=

--- a/main.go
+++ b/main.go
@@ -1,10 +1,26 @@
 package main
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5/server"
+	tfmux "github.com/hashicorp/terraform-plugin-mux"
+	protocol "github.com/hashicorp/terraform-provider-corner/internal/protocolprovider"
 	sdkv2 "github.com/hashicorp/terraform-provider-corner/internal/sdkv2provider"
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{ProviderFunc: sdkv2.New})
+	ctx := context.Background()
+	muxed, err := tfmux.NewSchemaServerFactory(ctx, sdkv2.New().GRPCProvider, protocol.Server)
+	if err != nil {
+		panic(err)
+	}
+
+	err = tf5server.Serve("registry.terraform.io/hashicorp/corner", func() tfprotov5.ProviderServer {
+		return muxed.Server()
+	})
+	if err != nil {
+		panic(err)
+	}
 }


### PR DESCRIPTION
Bump to latest versions of terraform-plugin-go and add terraform-plugin-mux. Note that this needs the latest master of https://github.com/hashicorp/terraform-plugin-sdk-private to compile.

At the main entry point, `plugin.Serve()` is replaced by `tfprotov5server.Serve()`, serving a muxed provider which implements both the SDKv2 resources (`corner_user` and `corner_regions`) and the protocol v5 resource (`corner_time`) as described in the final section of TF-266, which I'll update with more accurate code.

Acceptance testing will be added in the next PR - until then, this is best reviewed by compiling the provider and running it against config files manually.