### PR TITLE
Reproducing a bug with nested sets, lists and computed values

### DIFF
--- a/internal/tf6muxprovider/provider1/nested_resource.go
+++ b/internal/tf6muxprovider/provider1/nested_resource.go
@@ -1,0 +1,136 @@
+package provider1
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"math/rand"
+)
+
+type resourceNestedType struct{}
+
+func (r resourceNestedType) NewResource(_ context.Context, p provider.Provider) (resource.Resource, diag.Diagnostics) {
+	return resourceNested{
+		p: *(p.(*testProvider)),
+	}, nil
+}
+
+func (r resourceNestedType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
+	return tfsdk.Schema{
+		Attributes: map[string]tfsdk.Attribute{
+			"id": {
+				Type:     types.StringType,
+				Computed: true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					resource.UseStateForUnknown(),
+				},
+			},
+		},
+		Blocks: map[string]tfsdk.Block{
+			"set": {
+				Attributes: map[string]tfsdk.Attribute{
+					"id": {
+						Type:     types.StringType,
+						Computed: true,
+						Optional: true,
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							resource.UseStateForUnknown(),
+						},
+					},
+				},
+				Blocks: map[string]tfsdk.Block{
+					"list": {
+						Attributes: map[string]tfsdk.Attribute{
+							"id": {
+								Type:     types.StringType,
+								Computed: true,
+								PlanModifiers: []tfsdk.AttributePlanModifier{
+									resource.UseStateForUnknown(),
+								},
+							},
+						},
+						NestingMode: tfsdk.BlockNestingModeList,
+					},
+				},
+				NestingMode: tfsdk.BlockNestingModeSet,
+			},
+		},
+	}, nil
+}
+
+type resourceNested struct {
+	p testProvider
+}
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func id(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+type nested struct {
+	Id         types.String  `tfsdk:"id"`
+	NestedItem []*NestedItem `tfsdk:"set"`
+}
+
+type NestedItem struct {
+	Id               types.String        `tfsdk:"id"`
+	NestedNestedItem []*NestedNestedItem `tfsdk:"list"`
+}
+
+type NestedNestedItem struct {
+	Id types.String `tfsdk:"id"`
+}
+
+func (r resourceNested) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	nested := nested{}
+	diags := req.Plan.Get(ctx, &nested)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+
+	if nested.Id.IsUnknown() {
+		nested.Id = types.String{Value: id(8)}
+	}
+
+	for _, nst := range nested.NestedItem {
+		if nst.Id.IsUnknown() {
+			nst.Id = types.String{Value: id(8)}
+		}
+
+		for _, nstnst := range nst.NestedNestedItem {
+			nstnst.Id = types.String{Value: id(8)}
+		}
+	}
+
+	diags = resp.State.Set(ctx, nested)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+}
+
+func (r resourceNested) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	resp.State.Set(ctx, req.State.Raw)
+}
+
+func (r resourceNested) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	resp.State.Set(ctx, req.Plan.Raw)
+}
+
+func (r resourceNested) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	resp.State.RemoveResource(ctx)
+}
+
+func (r resourceNested) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/tf6muxprovider/provider1/nested_resource_test.go
+++ b/internal/tf6muxprovider/provider1/nested_resource_test.go
@@ -27,11 +27,11 @@ resource "tf6muxprovider_nested" "example" {
 
 	list {
 
-    }
+	}
 
 	list {
 
-    }
+	}
   }
 
   set {

--- a/internal/tf6muxprovider/provider1/nested_resource_test.go
+++ b/internal/tf6muxprovider/provider1/nested_resource_test.go
@@ -1,0 +1,41 @@
+package provider1
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccResourceNested(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"tf6muxprovider": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: configResourceNestedBasic,
+			},
+		},
+	})
+}
+
+const configResourceNestedBasic = `
+resource "tf6muxprovider_nested" "example" {
+  set {
+	id = "one"
+
+	list {
+
+    }
+
+	list {
+
+    }
+  }
+
+  set {
+	id = "two"
+  }
+}
+`

--- a/internal/tf6muxprovider/provider1/provider.go
+++ b/internal/tf6muxprovider/provider1/provider.go
@@ -39,7 +39,8 @@ func (p *testProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 
 func (p *testProvider) GetResources(_ context.Context) (map[string]provider.ResourceType, diag.Diagnostics) {
 	return map[string]provider.ResourceType{
-		"tf6muxprovider_user1": resourceUserType{},
+		"tf6muxprovider_user1":  resourceUserType{},
+		"tf6muxprovider_nested": resourceNestedType{},
 	}, nil
 }
 


### PR DESCRIPTION
The test case fails:

```
=== RUN   TestAccResourceNested
    nested_resource_test.go:11: Step 1/1 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # tf6muxprovider_nested.example will be updated in-place
          ~ resource "tf6muxprovider_nested" "example" {
                id = "XVlBzgba"
        
              - set {
                  - id = "two" -> null
        
                  - list {
                      - id = "iCMRAjWw" -> null
                    }
                  - list {
                      - id = "hTHctcuA" -> null
                    }
                }
              + set {
                  + id = "two"
        
                  + list {
                      + id = (known after apply)
                    }
                  + list {
                      + id = (known after apply)
                    }
                }
                # (1 unchanged block hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccResourceNested (0.46s)
```

I think the SDK is failing to preserve the computed values in the nested list. If you change the nested list type of `set` to be `NestingModeList` everything works as expected.