### PR TITLE
Updates for terraform-plugin-framework@v0.12.0

### DIFF
--- a/internal/framework5provider/provider.go
+++ b/internal/framework5provider/provider.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"os"
 
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-corner/internal/backend"
@@ -17,8 +19,10 @@ func New() provider.Provider {
 	return &testProvider{}
 }
 
-type testProvider struct {
-	client *backend.Client
+type testProvider struct{}
+
+func (p *testProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
+	resp.TypeName = "framework"
 }
 
 func (p *testProvider) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
@@ -37,15 +41,15 @@ func (p *testProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 	if err != nil {
 		resp.Diagnostics.AddError("Error initialising client", err.Error())
 	}
-	p.client = client
+	resp.ResourceData = client
 }
 
-func (p *testProvider) GetResources(_ context.Context) (map[string]provider.ResourceType, diag.Diagnostics) {
-	return map[string]provider.ResourceType{
-		"framework_user": resourceUserType{},
-	}, nil
+func (p *testProvider) Resources(_ context.Context) []func() resource.Resource {
+	return []func() resource.Resource{
+		NewUserResource,
+	}
 }
 
-func (p *testProvider) GetDataSources(_ context.Context) (map[string]provider.DataSourceType, diag.Diagnostics) {
-	return map[string]provider.DataSourceType{}, nil
+func (p *testProvider) DataSources(_ context.Context) []func() datasource.DataSource {
+	return nil
 }

--- a/internal/framework5provider/resource_user.go
+++ b/internal/framework5provider/resource_user.go
@@ -5,16 +5,31 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-corner/internal/backend"
 )
 
-type resourceUserType struct{}
+var (
+	_ resource.Resource                = &resourceUser{}
+	_ resource.ResourceWithConfigure   = &resourceUser{}
+	_ resource.ResourceWithImportState = &resourceUser{}
+)
 
-func (r resourceUserType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func NewUserResource() resource.Resource {
+	return &resourceUser{}
+}
+
+type resourceUser struct {
+	client *backend.Client
+}
+
+func (r *resourceUser) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_user"
+}
+
+func (r *resourceUser) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	return tfsdk.Schema{
 		Attributes: map[string]tfsdk.Attribute{
 			"email": {
@@ -54,14 +69,12 @@ func (r resourceUserType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagn
 	}, nil
 }
 
-func (r resourceUserType) NewResource(_ context.Context, p provider.Provider) (resource.Resource, diag.Diagnostics) {
-	return resourceUser{
-		p: *(p.(*testProvider)),
-	}, nil
-}
+func (r *resourceUser) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
 
-type resourceUser struct {
-	p testProvider
+	r.client = req.ProviderData.(*backend.Client)
 }
 
 type user struct {
@@ -73,7 +86,7 @@ type user struct {
 	Language   types.String `tfsdk:"language"`
 }
 
-func (r resourceUser) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+func (r *resourceUser) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan user
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -90,13 +103,13 @@ func (r resourceUser) Create(ctx context.Context, req resource.CreateRequest, re
 		newUser.Language = plan.Language.Value
 	}
 
-	err := r.p.client.CreateUser(newUser)
+	err := r.client.CreateUser(newUser)
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating user", err.Error())
 		return
 	}
 
-	p, err := r.p.client.ReadUser(newUser.Email)
+	p, err := r.client.ReadUser(newUser.Email)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading user", err.Error())
 		return
@@ -124,7 +137,7 @@ func (r resourceUser) Read(ctx context.Context, req resource.ReadRequest, resp *
 		return
 	}
 
-	p, err := r.p.client.ReadUser(state.Email)
+	p, err := r.client.ReadUser(state.Email)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading user", err.Error())
 		return
@@ -163,7 +176,7 @@ func (r resourceUser) Update(ctx context.Context, req resource.UpdateRequest, re
 		newUser.Language = plan.Language.Value
 	}
 
-	err := r.p.client.UpdateUser(newUser)
+	err := r.client.UpdateUser(newUser)
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating user", err.Error())
 		return
@@ -190,7 +203,7 @@ func (r resourceUser) Delete(ctx context.Context, req resource.DeleteRequest, re
 		Age:   state.Age,
 	}
 
-	err := r.p.client.DeleteUser(userToDelete)
+	err := r.client.DeleteUser(userToDelete)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting user", err.Error())
 		return

--- a/internal/framework6provider/provider.go
+++ b/internal/framework6provider/provider.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"os"
 
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-corner/internal/backend"
@@ -17,8 +19,10 @@ func New() provider.Provider {
 	return &testProvider{}
 }
 
-type testProvider struct {
-	client *backend.Client
+type testProvider struct{}
+
+func (p *testProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
+	resp.TypeName = "framework"
 }
 
 func (p *testProvider) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
@@ -37,15 +41,15 @@ func (p *testProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 	if err != nil {
 		resp.Diagnostics.AddError("Error initialising client", err.Error())
 	}
-	p.client = client
+	resp.ResourceData = client
 }
 
-func (p *testProvider) GetResources(_ context.Context) (map[string]provider.ResourceType, diag.Diagnostics) {
-	return map[string]provider.ResourceType{
-		"framework_user": resourceUserType{},
-	}, nil
+func (p *testProvider) Resources(_ context.Context) []func() resource.Resource {
+	return []func() resource.Resource{
+		NewUserResource,
+	}
 }
 
-func (p *testProvider) GetDataSources(_ context.Context) (map[string]provider.DataSourceType, diag.Diagnostics) {
-	return map[string]provider.DataSourceType{}, nil
+func (p *testProvider) DataSources(_ context.Context) []func() datasource.DataSource {
+	return nil
 }

--- a/internal/tf6muxprovider/provider1/provider.go
+++ b/internal/tf6muxprovider/provider1/provider.go
@@ -3,8 +3,10 @@ package provider1
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-corner/internal/backend"
@@ -14,8 +16,10 @@ func New() provider.Provider {
 	return &testProvider{}
 }
 
-type testProvider struct {
-	client *backend.Client
+type testProvider struct{}
+
+func (p *testProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
+	resp.TypeName = "tf6muxprovider"
 }
 
 func (p *testProvider) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
@@ -34,15 +38,15 @@ func (p *testProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 	if err != nil {
 		resp.Diagnostics.AddError("Error initialising client", err.Error())
 	}
-	p.client = client
+	resp.ResourceData = client
 }
 
-func (p *testProvider) GetResources(_ context.Context) (map[string]provider.ResourceType, diag.Diagnostics) {
-	return map[string]provider.ResourceType{
-		"tf6muxprovider_user1": resourceUserType{},
-	}, nil
+func (p *testProvider) Resources(_ context.Context) []func() resource.Resource {
+	return []func() resource.Resource{
+		NewUserResource,
+	}
 }
 
-func (p *testProvider) GetDataSources(_ context.Context) (map[string]provider.DataSourceType, diag.Diagnostics) {
-	return map[string]provider.DataSourceType{}, nil
+func (p *testProvider) DataSources(_ context.Context) []func() datasource.DataSource {
+	return nil
 }

--- a/internal/tf6muxprovider/provider1/resource_user.go
+++ b/internal/tf6muxprovider/provider1/resource_user.go
@@ -5,16 +5,31 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-corner/internal/backend"
 )
 
-type resourceUserType struct{}
+var (
+	_ resource.Resource                = &resourceUser{}
+	_ resource.ResourceWithConfigure   = &resourceUser{}
+	_ resource.ResourceWithImportState = &resourceUser{}
+)
 
-func (r resourceUserType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func NewUserResource() resource.Resource {
+	return &resourceUser{}
+}
+
+type resourceUser struct {
+	client *backend.Client
+}
+
+func (r *resourceUser) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_user1"
+}
+
+func (r *resourceUser) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	return tfsdk.Schema{
 		Attributes: map[string]tfsdk.Attribute{
 			"email": {
@@ -54,14 +69,12 @@ func (r resourceUserType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagn
 	}, nil
 }
 
-func (r resourceUserType) NewResource(_ context.Context, p provider.Provider) (resource.Resource, diag.Diagnostics) {
-	return resourceUser{
-		p: *(p.(*testProvider)),
-	}, nil
-}
+func (r *resourceUser) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
 
-type resourceUser struct {
-	p testProvider
+	r.client = req.ProviderData.(*backend.Client)
 }
 
 type user struct {
@@ -90,13 +103,13 @@ func (r resourceUser) Create(ctx context.Context, req resource.CreateRequest, re
 		newUser.Language = plan.Language.Value
 	}
 
-	err := r.p.client.CreateUser(newUser)
+	err := r.client.CreateUser(newUser)
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating user", err.Error())
 		return
 	}
 
-	p, err := r.p.client.ReadUser(newUser.Email)
+	p, err := r.client.ReadUser(newUser.Email)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading user", err.Error())
 		return
@@ -124,7 +137,7 @@ func (r resourceUser) Read(ctx context.Context, req resource.ReadRequest, resp *
 		return
 	}
 
-	p, err := r.p.client.ReadUser(state.Email)
+	p, err := r.client.ReadUser(state.Email)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading user", err.Error())
 		return
@@ -163,7 +176,7 @@ func (r resourceUser) Update(ctx context.Context, req resource.UpdateRequest, re
 		newUser.Language = plan.Language.Value
 	}
 
-	err := r.p.client.UpdateUser(newUser)
+	err := r.client.UpdateUser(newUser)
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating user", err.Error())
 		return
@@ -190,7 +203,7 @@ func (r resourceUser) Delete(ctx context.Context, req resource.DeleteRequest, re
 		Age:   state.Age,
 	}
 
-	err := r.p.client.DeleteUser(userToDelete)
+	err := r.client.DeleteUser(userToDelete)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting user", err.Error())
 		return

--- a/internal/tf6muxprovider/provider2/provider.go
+++ b/internal/tf6muxprovider/provider2/provider.go
@@ -3,8 +3,10 @@ package provider2
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-corner/internal/backend"
@@ -14,8 +16,10 @@ func New() provider.Provider {
 	return &testProvider{}
 }
 
-type testProvider struct {
-	client *backend.Client
+type testProvider struct{}
+
+func (p *testProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
+	resp.TypeName = "tf6muxprovider"
 }
 
 func (p *testProvider) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
@@ -34,15 +38,15 @@ func (p *testProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 	if err != nil {
 		resp.Diagnostics.AddError("Error initialising client", err.Error())
 	}
-	p.client = client
+	resp.ResourceData = client
 }
 
-func (p *testProvider) GetResources(_ context.Context) (map[string]provider.ResourceType, diag.Diagnostics) {
-	return map[string]provider.ResourceType{
-		"tf6muxprovider_user2": resourceUserType{},
-	}, nil
+func (p *testProvider) Resources(_ context.Context) []func() resource.Resource {
+	return []func() resource.Resource{
+		NewUserResource,
+	}
 }
 
-func (p *testProvider) GetDataSources(_ context.Context) (map[string]provider.DataSourceType, diag.Diagnostics) {
-	return map[string]provider.DataSourceType{}, nil
+func (p *testProvider) DataSources(_ context.Context) []func() datasource.DataSource {
+	return nil
 }

--- a/internal/tf6muxprovider/provider2/resource_user.go
+++ b/internal/tf6muxprovider/provider2/resource_user.go
@@ -5,16 +5,31 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-corner/internal/backend"
 )
 
-type resourceUserType struct{}
+var (
+	_ resource.Resource                = &resourceUser{}
+	_ resource.ResourceWithConfigure   = &resourceUser{}
+	_ resource.ResourceWithImportState = &resourceUser{}
+)
 
-func (r resourceUserType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func NewUserResource() resource.Resource {
+	return &resourceUser{}
+}
+
+type resourceUser struct {
+	client *backend.Client
+}
+
+func (r *resourceUser) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_user2"
+}
+
+func (r *resourceUser) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	return tfsdk.Schema{
 		Attributes: map[string]tfsdk.Attribute{
 			"email": {
@@ -54,14 +69,12 @@ func (r resourceUserType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagn
 	}, nil
 }
 
-func (r resourceUserType) NewResource(_ context.Context, p provider.Provider) (resource.Resource, diag.Diagnostics) {
-	return resourceUser{
-		p: *(p.(*testProvider)),
-	}, nil
-}
+func (r *resourceUser) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
 
-type resourceUser struct {
-	p testProvider
+	r.client = req.ProviderData.(*backend.Client)
 }
 
 type user struct {
@@ -90,13 +103,13 @@ func (r resourceUser) Create(ctx context.Context, req resource.CreateRequest, re
 		newUser.Language = plan.Language.Value
 	}
 
-	err := r.p.client.CreateUser(newUser)
+	err := r.client.CreateUser(newUser)
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating user", err.Error())
 		return
 	}
 
-	p, err := r.p.client.ReadUser(newUser.Email)
+	p, err := r.client.ReadUser(newUser.Email)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading user", err.Error())
 		return
@@ -124,7 +137,7 @@ func (r resourceUser) Read(ctx context.Context, req resource.ReadRequest, resp *
 		return
 	}
 
-	p, err := r.p.client.ReadUser(state.Email)
+	p, err := r.client.ReadUser(state.Email)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading user", err.Error())
 		return
@@ -163,7 +176,7 @@ func (r resourceUser) Update(ctx context.Context, req resource.UpdateRequest, re
 		newUser.Language = plan.Language.Value
 	}
 
-	err := r.p.client.UpdateUser(newUser)
+	err := r.client.UpdateUser(newUser)
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating user", err.Error())
 		return
@@ -190,7 +203,7 @@ func (r resourceUser) Delete(ctx context.Context, req resource.DeleteRequest, re
 		Age:   state.Age,
 	}
 
-	err := r.p.client.DeleteUser(userToDelete)
+	err := r.client.DeleteUser(userToDelete)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting user", err.Error())
 		return

--- a/internal/tf6to5provider/provider/provider.go
+++ b/internal/tf6to5provider/provider/provider.go
@@ -3,8 +3,10 @@ package provider
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-corner/internal/backend"
@@ -14,8 +16,10 @@ func New() provider.Provider {
 	return &testProvider{}
 }
 
-type testProvider struct {
-	client *backend.Client
+type testProvider struct{}
+
+func (p *testProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
+	resp.TypeName = "tf6to6provider"
 }
 
 func (p *testProvider) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
@@ -34,15 +38,15 @@ func (p *testProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 	if err != nil {
 		resp.Diagnostics.AddError("Error initialising client", err.Error())
 	}
-	p.client = client
+	resp.ResourceData = client
 }
 
-func (p *testProvider) GetResources(_ context.Context) (map[string]provider.ResourceType, diag.Diagnostics) {
-	return map[string]provider.ResourceType{
-		"tf6to5provider_user": resourceUserType{},
-	}, nil
+func (p *testProvider) Resources(_ context.Context) []func() resource.Resource {
+	return []func() resource.Resource{
+		NewUserResource,
+	}
 }
 
-func (p *testProvider) GetDataSources(_ context.Context) (map[string]provider.DataSourceType, diag.Diagnostics) {
-	return map[string]provider.DataSourceType{}, nil
+func (p *testProvider) DataSources(_ context.Context) []func() datasource.DataSource {
+	return nil
 }

--- a/internal/tf6to5provider/provider/provider.go
+++ b/internal/tf6to5provider/provider/provider.go
@@ -19,7 +19,7 @@ func New() provider.Provider {
 type testProvider struct{}
 
 func (p *testProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
-	resp.TypeName = "tf6to6provider"
+	resp.TypeName = "tf6to5provider"
 }
 
 func (p *testProvider) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {


### PR DESCRIPTION
- Replaces deprecated `provider.DataSourceType` and `provider.ResourceType` with `DataSource` and `Resource` methods respectively
- Moves the resource clients from being on the provider type to being passed during the provider `Configure` method
