### PR TITLE
.github/workflows: Test against Terraform 1.4 prerelease

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
           - '1.1.*'
           - '1.2.*'
           - '1.3.*'
-          - '1.4.0-alpha20221207'
+          - '1.4.0-beta1'
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
           - '1.1.*'
           - '1.2.*'
           - '1.3.*'
-          - '1.4.0-alpha20221109'
+          - '1.4.0-alpha20221207'
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
@@ -92,7 +92,7 @@ jobs:
           - '1.1.*'
           - '1.2.*'
           - '1.3.*'
-          - '1.4.0-alpha20221109'
+          - '1.4.0-alpha20221207'
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
           - '1.1.*'
           - '1.2.*'
           - '1.3.*'
-          - '1.4.0-beta1'
+          - '1.4.0-beta2'
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
@@ -92,7 +92,7 @@ jobs:
           - '1.1.*'
           - '1.2.*'
           - '1.3.*'
-          - '1.4.0-beta1'
+          - '1.4.0-beta2'
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,7 @@ jobs:
           - '1.1.*'
           - '1.2.*'
           - '1.3.*'
+          - '1.4.0-alpha20221109'
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
@@ -91,6 +92,7 @@ jobs:
           - '1.1.*'
           - '1.2.*'
           - '1.3.*'
+          - '1.4.0-alpha20221109'
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
           - '1.1.*'
           - '1.2.*'
           - '1.3.*'
-          - '1.4.0-beta2'
+          - '1.4.0-rc1'
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
@@ -92,7 +92,7 @@ jobs:
           - '1.1.*'
           - '1.2.*'
           - '1.3.*'
-          - '1.4.0-beta2'
+          - '1.4.0-rc1'
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
           - '1.1.*'
           - '1.2.*'
           - '1.3.*'
-          - '1.4.0-alpha20221207'
+          - '1.4.0-beta1'
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0


### PR DESCRIPTION
This is a branch that can be long-living, updated with new prereleases, then closed out (or updated to final and merged) when Terraform version 1.4.0 is released.