### PR TITLE
protocolprovider+protocolv6provider: Remove inconsequential Schema and Block Version fields

### DIFF
--- a/internal/protocolprovider/server.go
+++ b/internal/protocolprovider/server.go
@@ -59,16 +59,11 @@ func (s server) StopProvider(ctx context.Context, req *tfprotov5.StopProviderReq
 func Server() tfprotov5.ProviderServer {
 	return server{
 		providerSchema: &tfprotov5.Schema{
-			Version: 1,
-			Block: &tfprotov5.SchemaBlock{
-				Version: 1,
-			},
+			Block: &tfprotov5.SchemaBlock{},
 		},
 		dataSourceSchemas: map[string]*tfprotov5.Schema{
 			"corner_time": {
-				Version: 1,
 				Block: &tfprotov5.SchemaBlock{
-					Version: 1,
 					Attributes: []*tfprotov5.SchemaAttribute{
 						{
 							Name:            "current",

--- a/internal/protocolv6provider/server.go
+++ b/internal/protocolv6provider/server.go
@@ -59,16 +59,11 @@ func (s server) StopProvider(ctx context.Context, req *tfprotov6.StopProviderReq
 func Server() tfprotov6.ProviderServer {
 	return server{
 		providerSchema: &tfprotov6.Schema{
-			Version: 1,
-			Block: &tfprotov6.SchemaBlock{
-				Version: 1,
-			},
+			Block: &tfprotov6.SchemaBlock{},
 		},
 		dataSourceSchemas: map[string]*tfprotov6.Schema{
 			"corner_v6_time": {
-				Version: 1,
 				Block: &tfprotov6.SchemaBlock{
-					Version: 1,
 					Attributes: []*tfprotov6.SchemaAttribute{
 						{
 							Name:            "current",


### PR DESCRIPTION
Closes #22

terraform-plugin-go allows providers to specify these protocol level details, however their usage here is inconsequential to their purpose and can cause issues if attempting to combine these providers with terraform-plugin-sdk or terraform-plugin-framework providers via terraform-plugin-mux.