### PR TITLE
internal/framework(5|6)provider: Smoke testing for all attribute and …

### DIFF
--- a/internal/framework5provider/provider.go
+++ b/internal/framework5provider/provider.go
@@ -43,6 +43,7 @@ func (p *testProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 
 func (p *testProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
+		NewSchemaResource,
 		NewUserResource,
 	}
 }

--- a/internal/framework5provider/schema_resource.go
+++ b/internal/framework5provider/schema_resource.go
@@ -1,0 +1,151 @@
+package framework
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ resource.Resource = SchemaResource{}
+
+func NewSchemaResource() resource.Resource {
+	return &SchemaResource{}
+}
+
+// SchemaResource is for testing all schema types.
+type SchemaResource struct{}
+
+func (r SchemaResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_schema"
+}
+
+func (r SchemaResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"bool_attribute": schema.BoolAttribute{
+				Optional: true,
+			},
+			"float64_attribute": schema.Float64Attribute{
+				Optional: true,
+			},
+			// id attribute is required for acceptance testing.
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"int64_attribute": schema.Int64Attribute{
+				Optional: true,
+			},
+			"list_attribute": schema.ListAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+			"map_attribute": schema.MapAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+			"number_attribute": schema.NumberAttribute{
+				Optional: true,
+			},
+			"object_attribute": schema.ObjectAttribute{
+				AttributeTypes: map[string]attr.Type{
+					"object_attribute_attribute": types.StringType,
+				},
+				Optional: true,
+			},
+			"set_attribute": schema.SetAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+			"string_attribute": schema.StringAttribute{
+				Optional: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"list_nested_block": schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"list_nested_block_attribute": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			"set_nested_block": schema.SetNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"set_nested_block_attribute": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			"single_nested_block": schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"single_nested_block_attribute": schema.StringAttribute{
+						Optional: true,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r SchemaResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data SchemaResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Id = types.StringValue("test")
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r SchemaResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data SchemaResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r SchemaResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data SchemaResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r SchemaResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+}
+
+type SchemaResourceModel struct {
+	BoolAttribute     types.Bool    `tfsdk:"bool_attribute"`
+	Float64Attribute  types.Float64 `tfsdk:"float64_attribute"`
+	Id                types.String  `tfsdk:"id"`
+	Int64Attribute    types.Int64   `tfsdk:"int64_attribute"`
+	ListAttribute     types.List    `tfsdk:"list_attribute"`
+	ListNestedBlock   types.List    `tfsdk:"list_nested_block"`
+	MapAttribute      types.Map     `tfsdk:"map_attribute"`
+	NumberAttribute   types.Number  `tfsdk:"number_attribute"`
+	ObjectAttribute   types.Object  `tfsdk:"object_attribute"`
+	SetAttribute      types.Set     `tfsdk:"set_attribute"`
+	SetNestedBlock    types.Set     `tfsdk:"set_nested_block"`
+	SingleNestedBlock types.Object  `tfsdk:"single_nested_block"`
+	StringAttribute   types.String  `tfsdk:"string_attribute"`
+}

--- a/internal/framework5provider/schema_resource_test.go
+++ b/internal/framework5provider/schema_resource_test.go
@@ -1,0 +1,414 @@
+package framework
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestSchemaResource_basic(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
+			"framework": providerserver.NewProtocol5WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_BoolAttribute(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
+			"framework": providerserver.NewProtocol5WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					bool_attribute = true
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("framework_schema.test", "bool_attribute", "true"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_Float64Attribute(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
+			"framework": providerserver.NewProtocol5WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					float64_attribute = 1234.5
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "float64_attribute", "1234.5"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_Int64Attribute(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
+			"framework": providerserver.NewProtocol5WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					int64_attribute = 1234
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckResourceAttr("framework_schema.test", "int64_attribute", "1234"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_ListAttribute(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
+			"framework": providerserver.NewProtocol5WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					list_attribute = ["value1"]
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_attribute.#", "1"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_attribute.0", "value1"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_ListNestedBlock(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
+			"framework": providerserver.NewProtocol5WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					list_nested_block {
+						list_nested_block_attribute = "value1"
+					}
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "1"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.0.list_nested_block_attribute", "value1"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_MapAttribute(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
+			"framework": providerserver.NewProtocol5WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					map_attribute = {
+						key1 = "value1"
+					}
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckResourceAttr("framework_schema.test", "map_attribute.%", "1"),
+					resource.TestCheckResourceAttr("framework_schema.test", "map_attribute.key1", "value1"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_attribute.#", "0"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_NumberAttribute(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
+			"framework": providerserver.NewProtocol5WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					number_attribute = 1234.5
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "number_attribute", "1234.5"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_ObjectAttribute(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
+			"framework": providerserver.NewProtocol5WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					object_attribute = {
+						object_attribute_attribute = "value"
+					}
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "object_attribute.object_attribute_attribute", "value"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_SetAttribute(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
+			"framework": providerserver.NewProtocol5WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					set_attribute = ["value1"]
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_attribute.#", "1"),
+					resource.TestCheckTypeSetElemAttr("framework_schema.test", "set_attribute.*", "value1"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_SetNestedBlock(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
+			"framework": providerserver.NewProtocol5WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					set_nested_block {
+						set_nested_block_attribute = "value1"
+					}
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("framework_schema.test", "set_nested_block.*",
+						map[string]string{"set_nested_block_attribute": "value1"},
+					),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_SingleNestedBlock(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
+			"framework": providerserver.NewProtocol5WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					single_nested_block {
+						single_nested_block_attribute = "value"
+					}
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckResourceAttr("framework_schema.test", "single_nested_block.single_nested_block_attribute", "value"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_StringAttribute(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
+			"framework": providerserver.NewProtocol5WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					string_attribute = "value"
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckResourceAttr("framework_schema.test", "string_attribute", "value"),
+				),
+			},
+		},
+	})
+}

--- a/internal/framework6provider/provider.go
+++ b/internal/framework6provider/provider.go
@@ -43,6 +43,7 @@ func (p *testProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 
 func (p *testProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
+		NewSchemaResource,
 		NewUserResource,
 	}
 }

--- a/internal/framework6provider/schema_resource.go
+++ b/internal/framework6provider/schema_resource.go
@@ -1,0 +1,193 @@
+package framework
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ resource.Resource = SchemaResource{}
+
+func NewSchemaResource() resource.Resource {
+	return &SchemaResource{}
+}
+
+// SchemaResource is for testing all schema types.
+type SchemaResource struct{}
+
+func (r SchemaResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_schema"
+}
+
+func (r SchemaResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"bool_attribute": schema.BoolAttribute{
+				Optional: true,
+			},
+			"float64_attribute": schema.Float64Attribute{
+				Optional: true,
+			},
+			// id attribute is required for acceptance testing.
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"int64_attribute": schema.Int64Attribute{
+				Optional: true,
+			},
+			"list_attribute": schema.ListAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+			"list_nested_attribute": schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"list_nested_attribute_attribute": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+				Optional: true,
+			},
+			"map_attribute": schema.MapAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+			"map_nested_attribute": schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"map_nested_attribute_attribute": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+				Optional: true,
+			},
+			"number_attribute": schema.NumberAttribute{
+				Optional: true,
+			},
+			"object_attribute": schema.ObjectAttribute{
+				AttributeTypes: map[string]attr.Type{
+					"object_attribute_attribute": types.StringType,
+				},
+				Optional: true,
+			},
+			"set_attribute": schema.SetAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+			"set_nested_attribute": schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"set_nested_attribute_attribute": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+				Optional: true,
+			},
+			"single_nested_attribute": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"single_nested_attribute_attribute": schema.StringAttribute{
+						Optional: true,
+					},
+				},
+				Optional: true,
+			},
+			"string_attribute": schema.StringAttribute{
+				Optional: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"list_nested_block": schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"list_nested_block_attribute": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			"set_nested_block": schema.SetNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"set_nested_block_attribute": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			"single_nested_block": schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"single_nested_block_attribute": schema.StringAttribute{
+						Optional: true,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r SchemaResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data SchemaResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Id = types.StringValue("test")
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r SchemaResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data SchemaResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r SchemaResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data SchemaResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r SchemaResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+}
+
+type SchemaResourceModel struct {
+	BoolAttribute         types.Bool    `tfsdk:"bool_attribute"`
+	Float64Attribute      types.Float64 `tfsdk:"float64_attribute"`
+	Id                    types.String  `tfsdk:"id"`
+	Int64Attribute        types.Int64   `tfsdk:"int64_attribute"`
+	ListAttribute         types.List    `tfsdk:"list_attribute"`
+	ListNestedAttribute   types.List    `tfsdk:"list_nested_attribute"`
+	ListNestedBlock       types.List    `tfsdk:"list_nested_block"`
+	MapAttribute          types.Map     `tfsdk:"map_attribute"`
+	MapNestedAttribute    types.Map     `tfsdk:"map_nested_attribute"`
+	NumberAttribute       types.Number  `tfsdk:"number_attribute"`
+	ObjectAttribute       types.Object  `tfsdk:"object_attribute"`
+	SetAttribute          types.Set     `tfsdk:"set_attribute"`
+	SetNestedAttribute    types.Set     `tfsdk:"set_nested_attribute"`
+	SetNestedBlock        types.Set     `tfsdk:"set_nested_block"`
+	SingleNestedAttribute types.Object  `tfsdk:"single_nested_attribute"`
+	SingleNestedBlock     types.Object  `tfsdk:"single_nested_block"`
+	StringAttribute       types.String  `tfsdk:"string_attribute"`
+}

--- a/internal/framework6provider/schema_resource_test.go
+++ b/internal/framework6provider/schema_resource_test.go
@@ -1,0 +1,621 @@
+package framework
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestSchemaResource_basic(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_BoolAttribute(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					bool_attribute = true
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("framework_schema.test", "bool_attribute", "true"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_Float64Attribute(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					float64_attribute = 1234.5
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "float64_attribute", "1234.5"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_Int64Attribute(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					int64_attribute = 1234
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckResourceAttr("framework_schema.test", "int64_attribute", "1234"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_ListAttribute(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					list_attribute = ["value1"]
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_attribute.#", "1"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_attribute.0", "value1"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_ListNestedAttribute(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					list_nested_attribute = [
+						{
+							list_nested_attribute_attribute = "value1"
+						},
+					]
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_attribute.#", "1"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_attribute.0.list_nested_attribute_attribute", "value1"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_ListNestedBlock(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					list_nested_block {
+						list_nested_block_attribute = "value1"
+					}
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "1"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.0.list_nested_block_attribute", "value1"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_MapAttribute(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					map_attribute = {
+						key1 = "value1"
+					}
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckResourceAttr("framework_schema.test", "map_attribute.%", "1"),
+					resource.TestCheckResourceAttr("framework_schema.test", "map_attribute.key1", "value1"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_attribute.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_MapNestedAttribute(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					map_nested_attribute = {
+						"key1" = {
+							map_nested_attribute_attribute = "value1"
+						},
+					}
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "map_nested_attribute.%", "1"),
+					resource.TestCheckResourceAttr("framework_schema.test", "map_nested_attribute.key1.map_nested_attribute_attribute", "value1"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_attribute.#", "0"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_NumberAttribute(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					number_attribute = 1234.5
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "number_attribute", "1234.5"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_ObjectAttribute(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					object_attribute = {
+						object_attribute_attribute = "value"
+					}
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "object_attribute.object_attribute_attribute", "value"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_SetAttribute(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					set_attribute = ["value1"]
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_attribute.#", "1"),
+					resource.TestCheckTypeSetElemAttr("framework_schema.test", "set_attribute.*", "value1"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_SetNestedAttribute(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					set_nested_attribute = [
+						{
+							set_nested_attribute_attribute = "value1"
+						},
+					]
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_attribute.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("framework_schema.test", "set_nested_attribute.*",
+						map[string]string{"set_nested_attribute_attribute": "value1"},
+					),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_SetNestedBlock(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					set_nested_block {
+						set_nested_block_attribute = "value1"
+					}
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("framework_schema.test", "set_nested_block.*",
+						map[string]string{"set_nested_block_attribute": "value1"},
+					),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_SingleNestedAttribute(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					single_nested_attribute = {
+						single_nested_attribute_attribute = "value"
+					}
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckResourceAttr("framework_schema.test", "single_nested_attribute.single_nested_attribute_attribute", "value"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_SingleNestedBlock(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					single_nested_block {
+						single_nested_block_attribute = "value"
+					}
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "single_nested_block.single_nested_block_attribute", "value"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "string_attribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestSchemaResource_StringAttribute(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_schema" "test" {
+					string_attribute = "value"
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("framework_schema.test", "bool_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "float64_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "id", "test"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "int64_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "list_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "list_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "map_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "number_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "object_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "set_nested_attribute"),
+					resource.TestCheckResourceAttr("framework_schema.test", "set_nested_block.#", "0"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_attribute"),
+					resource.TestCheckNoResourceAttr("framework_schema.test", "single_nested_block"),
+					resource.TestCheckResourceAttr("framework_schema.test", "string_attribute", "value"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/623

This sort of end-to-end testing would have caught the data handling issue before the framework v1.1.0 release:

Running the testing with framework v1.1.0:

```
=== RUN   TestSchemaResource_basic
panic: tftypes.NewValue can't use []tftypes.Value as a tftypes.Object; expected types are: map[string]tftypes.Value

goroutine 2659 [running]:
github.com/hashicorp/terraform-plugin-go/tftypes.NewValue(...)
        /Users/bflad/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.14.3/tftypes/value.go:273
github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata.(*Data).ReifyNullCollectionBlocks.func1(0x101922568?, {{0x101922510?, 0x140002824e0?}, {0x0?, 0x0?}})
```