### PR TITLE
.github/workflows: Add sdkv2testingprovider to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,9 @@ jobs:
       - run: go test -v -cover ./internal/sdkv2provider/
         env:
           TF_ACC: "1"
+      - run: go test -v -cover ./internal/sdkv2testingprovider/
+        env:
+          TF_ACC: "1"
       - run: go test -v -cover ./internal/tf5muxprovider/
       - run: go test -v -cover ./internal/tf6to5provider/
 


### PR DESCRIPTION
Missed in https://github.com/hashicorp/terraform-provider-corner/pull/126, my bad.