### PR TITLE
Bump Go version to 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-provider-corner
 
-go 1.18
+go 1.19
 
 require (
 	github.com/hashicorp/go-memdb v1.3.4


### PR DESCRIPTION
In preparation for upgrading all the `terraform-plugin-*` Go module minimums.

Updated via:

```shell
go mod edit -go=1.19
go mod tidy
go fix ./...
```