### PR TITLE
.github/workflows: Test on Terraform 1.6.* versions 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
           - '1.3.*'
           - '1.4.*'
           - '1.5.*'
-          - '1.6.0-alpha20230816'
+          - '1.6.*'
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
@@ -101,7 +101,7 @@ jobs:
           - '1.3.*'
           - '1.4.*'
           - '1.5.*'
-          - '1.6.0-alpha20230816'
+          - '1.6.*'
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0


### PR DESCRIPTION
Terraform 1.6 released: https://github.com/hashicorp/terraform/releases/tag/v1.6.0