### PR TITLE
Prevent missing method MoveResourceState

### DIFF
--- a/internal/protocolprovider/resource_router.go
+++ b/internal/protocolprovider/resource_router.go
@@ -64,3 +64,21 @@ func (r resourceRouter) ImportResourceState(ctx context.Context, req *tfprotov5.
 	}
 	return res.ImportResourceState(ctx, req)
 }
+
+func (r resourceRouter) MoveResourceState(ctx context.Context, req *tfprotov5.MoveResourceStateRequest) (*tfprotov5.MoveResourceStateResponse, error) {
+	_, ok := r[req.TargetTypeName]
+	if !ok {
+		return nil, errUnsupportedResource(req.TargetTypeName)
+	}
+	// If this support ever needs to be added, this can follow the existing
+	// pattern of calling res.MoveResourceState(ctx, req).
+	return &tfprotov5.MoveResourceStateResponse{
+		Diagnostics: []*tfprotov5.Diagnostic{
+			{
+				Severity: tfprotov5.DiagnosticSeverityError,
+				Summary:  "Unsupported Resource Operation",
+				Detail:   "MoveResourceState is not supported by this provider.",
+			},
+		},
+	}, nil
+}

--- a/internal/protocolv6provider/resource_router.go
+++ b/internal/protocolv6provider/resource_router.go
@@ -64,3 +64,21 @@ func (r resourceRouter) ImportResourceState(ctx context.Context, req *tfprotov6.
 	}
 	return res.ImportResourceState(ctx, req)
 }
+
+func (r resourceRouter) MoveResourceState(ctx context.Context, req *tfprotov6.MoveResourceStateRequest) (*tfprotov6.MoveResourceStateResponse, error) {
+	_, ok := r[req.TargetTypeName]
+	if !ok {
+		return nil, errUnsupportedResource(req.TargetTypeName)
+	}
+	// If this support ever needs to be added, this can follow the existing
+	// pattern of calling res.MoveResourceState(ctx, req).
+	return &tfprotov6.MoveResourceStateResponse{
+		Diagnostics: []*tfprotov6.Diagnostic{
+			{
+				Severity: tfprotov6.DiagnosticSeverityError,
+				Summary:  "Unsupported Resource Operation",
+				Detail:   "MoveResourceState is not supported by this provider.",
+			},
+		},
+	}, nil
+}


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-go/pull/388

These changes are so the testing provider is compliant with the upcoming `tfprotov5` and `tfprotov6` packages which require provider implementations to fully implement function server handling (already covered) and MoveResourceState (needs covering, hence this change). Almost the entire ecosystem will not have this issue as the higher level SDKs (terraform-plugin-framework, terraform-plugin-sdk, etc.) handle these protocol operations automatically by nature of updating the dependency, but this test provider is written directly in the low level SDK, so it must implement the necessary changes itself prior to that upstream breaking change.