### PR TITLE
Updating provider-defined functions to use named parameters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,5 +65,3 @@ require (
 	google.golang.org/grpc v1.62.1 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 )
-
-replace github.com/hashicorp/terraform-plugin-framework => /Users/bdb/go/src/github/hashicorp/terraform-plugin-framework

--- a/go.mod
+++ b/go.mod
@@ -65,3 +65,5 @@ require (
 	google.golang.org/grpc v1.62.1 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 )
+
+replace github.com/hashicorp/terraform-plugin-framework => /Users/bdb/go/src/github/hashicorp/terraform-plugin-framework

--- a/internal/framework5provider/bool_function.go
+++ b/internal/framework5provider/bool_function.go
@@ -24,7 +24,9 @@ func (f BoolFunction) Metadata(ctx context.Context, req function.MetadataRequest
 func (f BoolFunction) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
 	resp.Definition = function.Definition{
 		Parameters: []function.Parameter{
-			function.BoolParameter{},
+			function.BoolParameter{
+				Name: "bool_param",
+			},
 		},
 		Return: function.BoolReturn{},
 	}

--- a/internal/framework5provider/float64_function.go
+++ b/internal/framework5provider/float64_function.go
@@ -24,7 +24,9 @@ func (f Float64Function) Metadata(ctx context.Context, req function.MetadataRequ
 func (f Float64Function) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
 	resp.Definition = function.Definition{
 		Parameters: []function.Parameter{
-			function.Float64Parameter{},
+			function.Float64Parameter{
+				Name: "float64_param",
+			},
 		},
 		Return: function.Float64Return{},
 	}

--- a/internal/framework5provider/int64_function.go
+++ b/internal/framework5provider/int64_function.go
@@ -24,7 +24,9 @@ func (f Int64Function) Metadata(ctx context.Context, req function.MetadataReques
 func (f Int64Function) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
 	resp.Definition = function.Definition{
 		Parameters: []function.Parameter{
-			function.Int64Parameter{},
+			function.Int64Parameter{
+				Name: "int64_param",
+			},
 		},
 		Return: function.Int64Return{},
 	}

--- a/internal/framework5provider/list_function.go
+++ b/internal/framework5provider/list_function.go
@@ -27,6 +27,7 @@ func (f ListFunction) Definition(ctx context.Context, req function.DefinitionReq
 		Parameters: []function.Parameter{
 			function.ListParameter{
 				ElementType: types.StringType,
+				Name:        "list_param",
 			},
 		},
 		Return: function.ListReturn{

--- a/internal/framework5provider/map_function.go
+++ b/internal/framework5provider/map_function.go
@@ -27,6 +27,7 @@ func (f MapFunction) Definition(ctx context.Context, req function.DefinitionRequ
 		Parameters: []function.Parameter{
 			function.MapParameter{
 				ElementType: types.StringType,
+				Name:        "map_param",
 			},
 		},
 		Return: function.MapReturn{

--- a/internal/framework5provider/number_function.go
+++ b/internal/framework5provider/number_function.go
@@ -25,7 +25,9 @@ func (f NumberFunction) Metadata(ctx context.Context, req function.MetadataReque
 func (f NumberFunction) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
 	resp.Definition = function.Definition{
 		Parameters: []function.Parameter{
-			function.NumberParameter{},
+			function.NumberParameter{
+				Name: "number_param",
+			},
 		},
 		Return: function.NumberReturn{},
 	}

--- a/internal/framework5provider/number_function_test.go
+++ b/internal/framework5provider/number_function_test.go
@@ -20,12 +20,10 @@ import (
 
 func TestNumberFunction_known(t *testing.T) {
 	// Using 9223372036854775808, the smallest number that can't be represented as an int64,
-	// results in an Terraform error where [Planned value does not match config value for cty.NumberIntVal],
-	// which is related to a bug in go.cty relating to [Large integer comparisons and msgpack encoding].
+	// results in an Terraform error where [Planned value does not match config value for number].
 	// A value of 9223372036854775809 is used for the meanwhile.
 	//
-	// [Planned value does not match config value for cty.NumberIntVal]: https://github.com/hashicorp/terraform/issues/34589
-	// [Large integer comparisons and msgpack encoding]: https://github.com/zclconf/go-cty/pull/176
+	// [Planned value does not match config value for number]: https://github.com/hashicorp/terraform/issues/34866
 	bf, _, err := big.ParseFloat("9223372036854775809", 10, 512, big.ToNearestEven)
 
 	if err != nil {

--- a/internal/framework5provider/object_function.go
+++ b/internal/framework5provider/object_function.go
@@ -31,6 +31,7 @@ func (f ObjectFunction) Definition(ctx context.Context, req function.DefinitionR
 					"attr1": types.StringType,
 					"attr2": types.Int64Type,
 				},
+				Name: "object_param",
 			},
 		},
 		Return: function.ObjectReturn{

--- a/internal/framework5provider/set_function.go
+++ b/internal/framework5provider/set_function.go
@@ -27,6 +27,7 @@ func (f SetFunction) Definition(ctx context.Context, req function.DefinitionRequ
 		Parameters: []function.Parameter{
 			function.SetParameter{
 				ElementType: types.StringType,
+				Name:        "set_param",
 			},
 		},
 		Return: function.SetReturn{

--- a/internal/framework5provider/string_function.go
+++ b/internal/framework5provider/string_function.go
@@ -24,7 +24,9 @@ func (f StringFunction) Metadata(ctx context.Context, req function.MetadataReque
 func (f StringFunction) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
 	resp.Definition = function.Definition{
 		Parameters: []function.Parameter{
-			function.StringParameter{},
+			function.StringParameter{
+				Name: "string_param",
+			},
 		},
 		Return: function.StringReturn{},
 	}

--- a/internal/framework5provider/variadic_function.go
+++ b/internal/framework5provider/variadic_function.go
@@ -27,7 +27,9 @@ func (f VariadicFunction) Definition(ctx context.Context, req function.Definitio
 		Return: function.ListReturn{
 			ElementType: types.StringType,
 		},
-		VariadicParameter: function.StringParameter{},
+		VariadicParameter: function.StringParameter{
+			Name: "variadic_param",
+		},
 	}
 }
 

--- a/internal/framework6provider/bool_function.go
+++ b/internal/framework6provider/bool_function.go
@@ -24,7 +24,9 @@ func (f BoolFunction) Metadata(ctx context.Context, req function.MetadataRequest
 func (f BoolFunction) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
 	resp.Definition = function.Definition{
 		Parameters: []function.Parameter{
-			function.BoolParameter{},
+			function.BoolParameter{
+				Name: "bool_param",
+			},
 		},
 		Return: function.BoolReturn{},
 	}

--- a/internal/framework6provider/float64_function.go
+++ b/internal/framework6provider/float64_function.go
@@ -24,7 +24,9 @@ func (f Float64Function) Metadata(ctx context.Context, req function.MetadataRequ
 func (f Float64Function) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
 	resp.Definition = function.Definition{
 		Parameters: []function.Parameter{
-			function.Float64Parameter{},
+			function.Float64Parameter{
+				Name: "float64_param",
+			},
 		},
 		Return: function.Float64Return{},
 	}

--- a/internal/framework6provider/int64_function.go
+++ b/internal/framework6provider/int64_function.go
@@ -24,7 +24,9 @@ func (f Int64Function) Metadata(ctx context.Context, req function.MetadataReques
 func (f Int64Function) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
 	resp.Definition = function.Definition{
 		Parameters: []function.Parameter{
-			function.Int64Parameter{},
+			function.Int64Parameter{
+				Name: "int64_param",
+			},
 		},
 		Return: function.Int64Return{},
 	}

--- a/internal/framework6provider/list_function.go
+++ b/internal/framework6provider/list_function.go
@@ -27,6 +27,7 @@ func (f ListFunction) Definition(ctx context.Context, req function.DefinitionReq
 		Parameters: []function.Parameter{
 			function.ListParameter{
 				ElementType: types.StringType,
+				Name:        "list_param",
 			},
 		},
 		Return: function.ListReturn{

--- a/internal/framework6provider/map_function.go
+++ b/internal/framework6provider/map_function.go
@@ -27,6 +27,7 @@ func (f MapFunction) Definition(ctx context.Context, req function.DefinitionRequ
 		Parameters: []function.Parameter{
 			function.MapParameter{
 				ElementType: types.StringType,
+				Name:        "map_param",
 			},
 		},
 		Return: function.MapReturn{

--- a/internal/framework6provider/number_function.go
+++ b/internal/framework6provider/number_function.go
@@ -25,7 +25,9 @@ func (f NumberFunction) Metadata(ctx context.Context, req function.MetadataReque
 func (f NumberFunction) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
 	resp.Definition = function.Definition{
 		Parameters: []function.Parameter{
-			function.NumberParameter{},
+			function.NumberParameter{
+				Name: "number_param",
+			},
 		},
 		Return: function.NumberReturn{},
 	}

--- a/internal/framework6provider/number_function_test.go
+++ b/internal/framework6provider/number_function_test.go
@@ -19,7 +19,12 @@ import (
 )
 
 func TestNumberFunction_known(t *testing.T) {
-	bf, _, err := big.ParseFloat("9223372036854775808", 10, 512, big.ToNearestEven)
+	// Using 9223372036854775808, the smallest number that can't be represented as an int64,
+	// results in an Terraform error where [Planned value does not match config value for number].
+	// A value of 9223372036854775809 is used for the meanwhile.
+	//
+	// [Planned value does not match config value for number]: https://github.com/hashicorp/terraform/issues/34866
+	bf, _, err := big.ParseFloat("9223372036854775809", 10, 512, big.ToNearestEven)
 
 	if err != nil {
 		t.Errorf("%s", err)

--- a/internal/framework6provider/object_function.go
+++ b/internal/framework6provider/object_function.go
@@ -31,6 +31,7 @@ func (f ObjectFunction) Definition(ctx context.Context, req function.DefinitionR
 					"attr1": types.StringType,
 					"attr2": types.Int64Type,
 				},
+				Name: "object_param",
 			},
 		},
 		Return: function.ObjectReturn{

--- a/internal/framework6provider/set_function.go
+++ b/internal/framework6provider/set_function.go
@@ -27,6 +27,7 @@ func (f SetFunction) Definition(ctx context.Context, req function.DefinitionRequ
 		Parameters: []function.Parameter{
 			function.SetParameter{
 				ElementType: types.StringType,
+				Name:        "set_param",
 			},
 		},
 		Return: function.SetReturn{

--- a/internal/framework6provider/string_function.go
+++ b/internal/framework6provider/string_function.go
@@ -24,7 +24,9 @@ func (f StringFunction) Metadata(ctx context.Context, req function.MetadataReque
 func (f StringFunction) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
 	resp.Definition = function.Definition{
 		Parameters: []function.Parameter{
-			function.StringParameter{},
+			function.StringParameter{
+				Name: "string_param",
+			},
 		},
 		Return: function.StringReturn{},
 	}

--- a/internal/framework6provider/variadic_function.go
+++ b/internal/framework6provider/variadic_function.go
@@ -27,7 +27,9 @@ func (f VariadicFunction) Definition(ctx context.Context, req function.Definitio
 		Return: function.ListReturn{
 			ElementType: types.StringType,
 		},
-		VariadicParameter: function.StringParameter{},
+		VariadicParameter: function.StringParameter{
+			Name: "variadic_param",
+		},
 	}
 }
 

--- a/internal/tf6muxprovider/provider1/function_string.go
+++ b/internal/tf6muxprovider/provider1/function_string.go
@@ -24,7 +24,9 @@ func (f StringFunction) Metadata(ctx context.Context, req function.MetadataReque
 func (f StringFunction) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
 	resp.Definition = function.Definition{
 		Parameters: []function.Parameter{
-			function.StringParameter{},
+			function.StringParameter{
+				Name: "string1_param",
+			},
 		},
 		Return: function.StringReturn{},
 	}

--- a/internal/tf6muxprovider/provider2/function_string.go
+++ b/internal/tf6muxprovider/provider2/function_string.go
@@ -24,7 +24,9 @@ func (f StringFunction) Metadata(ctx context.Context, req function.MetadataReque
 func (f StringFunction) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
 	resp.Definition = function.Definition{
 		Parameters: []function.Parameter{
-			function.StringParameter{},
+			function.StringParameter{
+				Name: "string2_param",
+			},
 		},
 		Return: function.StringReturn{},
 	}

--- a/internal/tf6to5provider/provider/function_string.go
+++ b/internal/tf6to5provider/provider/function_string.go
@@ -24,7 +24,9 @@ func (f StringFunction) Metadata(ctx context.Context, req function.MetadataReque
 func (f StringFunction) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
 	resp.Definition = function.Definition{
 		Parameters: []function.Parameter{
-			function.StringParameter{},
+			function.StringParameter{
+				Name: "string_param",
+			},
 		},
 		Return: function.StringReturn{},
 	}


### PR DESCRIPTION
With the update to the plugin framework that now [requires all provider-defined function parameters are named](https://github.com/hashicorp/terraform-plugin-framework/pull/964), this repo needs to be updated to add parameter names throughout.

Changes were evaluated by:

- Building a local Terraform binary from `v1.8.0-beta1`
- Temporarily switching all `tfversion.SkipBelow(tfversion.Version1_8_0)` to `tfversion.SkipBelow(tfversion.Version1_7_0)`
- Temporarily updating `go.mod` to use the branch of the plugin framework containing the [changes requiring all function parameters are named](https://github.com/hashicorp/terraform-plugin-framework/pull/964).
- Running the tests  