### PR TITLE
internal: Remove `id` attribute from all resource tests

### DIFF
--- a/internal/framework5provider/dynamic_schema_resource_test.go
+++ b/internal/framework5provider/dynamic_schema_resource_test.go
@@ -34,9 +34,7 @@ import (
 //	Terraform will perform the following actions:
 //
 //	  # framework_dynamic_schema.test will be updated in-place
-//	  ~ resource "framework_dynamic_schema" "test" {
-//			id = "test"
-//		}
+//	  ~ resource "framework_dynamic_schema" "test" {}
 //
 //	Plan: 0 to add, 1 to change, 0 to destroy.
 func TestDynamicSchemaResource_null(t *testing.T) {

--- a/internal/framework5provider/float64_precision_resource.go
+++ b/internal/framework5provider/float64_precision_resource.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -30,13 +28,6 @@ func (r Float64PrecisionResource) Metadata(_ context.Context, req resource.Metad
 func (r Float64PrecisionResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			// id attribute is required for acceptance testing.
-			"id": schema.StringAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
 			"float64_attribute": schema.Float64Attribute{
 				Optional: true,
 				Computed: true,
@@ -56,7 +47,6 @@ func (r Float64PrecisionResource) Create(ctx context.Context, req resource.Creat
 
 	// Test semantic equality by losing the precision of the initial *big.Float
 	data.Float64Attribute = types.Float64Value(data.Float64Attribute.ValueFloat64())
-	data.Id = types.StringValue("test")
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -92,6 +82,5 @@ func (r Float64PrecisionResource) Delete(ctx context.Context, req resource.Delet
 }
 
 type Float64PrecisionResourceModel struct {
-	Id               types.String  `tfsdk:"id"`
 	Float64Attribute types.Float64 `tfsdk:"float64_attribute"`
 }

--- a/internal/framework5provider/resource_user.go
+++ b/internal/framework5provider/resource_user.go
@@ -48,10 +48,6 @@ func (r *resourceUser) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			"age": schema.NumberAttribute{
 				Required: true,
 			},
-			// included only for compatibility with SDKv2 test framework
-			"id": schema.StringAttribute{
-				Optional: true,
-			},
 			"date_joined": schema.StringAttribute{
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
@@ -86,7 +82,6 @@ type user struct {
 	Email      string       `tfsdk:"email"`
 	Name       string       `tfsdk:"name"`
 	Age        int          `tfsdk:"age"`
-	Id         string       `tfsdk:"id"`
 	DateJoined types.String `tfsdk:"date_joined"`
 	Language   types.String `tfsdk:"language"`
 }

--- a/internal/framework5provider/resource_user_test.go
+++ b/internal/framework5provider/resource_user_test.go
@@ -27,8 +27,6 @@ func TestAccFrameworkResourceUser(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"framework_user.foo", "age", "200"),
 					resource.TestCheckResourceAttr(
-						"framework_user.foo", "id", "h"),
-					resource.TestCheckResourceAttr(
 						"framework_user.foo", "language", "en"),
 				),
 			},
@@ -51,8 +49,6 @@ func TestAccFrameworkResourceUser_language(t *testing.T) {
 						"framework_user.foo", "email", "jdoe@example.com"),
 					resource.TestCheckResourceAttr(
 						"framework_user.foo", "age", "18"),
-					resource.TestCheckResourceAttr(
-						"framework_user.foo", "id", "jdoe"),
 					resource.TestCheckResourceAttr(
 						"framework_user.foo", "language", "es"),
 				),
@@ -82,8 +78,6 @@ func TestAccFrameworkResourceUser_interpolateLanguage(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"framework_user.foo", "age", "200"),
 					resource.TestCheckResourceAttr(
-						"framework_user.foo", "id", "h"),
-					resource.TestCheckResourceAttr(
 						"framework_user.foo", "language", "en"),
 				),
 			},
@@ -96,8 +90,6 @@ func TestAccFrameworkResourceUser_interpolateLanguage(t *testing.T) {
 						"framework_user.foo", "email", "ford@prefect.co"),
 					resource.TestCheckResourceAttr(
 						"framework_user.foo", "age", "200"),
-					resource.TestCheckResourceAttr(
-						"framework_user.foo", "id", "h"),
 					resource.TestCheckResourceAttr(
 						"framework_user.foo", "language", "es"),
 				),
@@ -127,7 +119,6 @@ resource "framework_user" "test" {
   email = "ford@prefect.co"
   name  = var.framework_user_name
   age   = 200
-  id    = "h"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -143,7 +134,6 @@ resource "framework_user" "foo" {
   email = "ford@prefect.co"
   name = "Ford Prefect"
   age = 200
-  id = "h"
 }
 `
 
@@ -152,7 +142,6 @@ resource "framework_user" "foo" {
   email = "jdoe@example.com"
   name = "J Doe"
   age = 18
-  id = "jdoe"
   language = "es"
 }
 `
@@ -167,7 +156,6 @@ resource "framework_user" "foo" {
   email = "ford@prefect.co"
   name = "Ford Prefect"
   age = 200
-  id = "h"
   language = random_shuffle.foo.result[0]
 }
 `

--- a/internal/framework5provider/timeouts_resource.go
+++ b/internal/framework5provider/timeouts_resource.go
@@ -9,9 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 var _ resource.Resource = TimeoutsResource{}
@@ -29,15 +26,6 @@ func (r TimeoutsResource) Metadata(_ context.Context, req resource.MetadataReque
 
 func (r TimeoutsResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Attributes: map[string]schema.Attribute{
-			// id attribute is required for acceptance testing.
-			"id": schema.StringAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-		},
 		Blocks: map[string]schema.Block{
 			"timeouts": timeouts.Block(ctx, timeouts.Opts{
 				Create: true,
@@ -54,8 +42,6 @@ func (r TimeoutsResource) Create(ctx context.Context, req resource.CreateRequest
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	data.Id = types.StringValue("test")
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -88,6 +74,5 @@ func (r TimeoutsResource) Delete(ctx context.Context, req resource.DeleteRequest
 }
 
 type TimeoutsResourceModel struct {
-	Id       types.String   `tfsdk:"id"`
 	Timeouts timeouts.Value `tfsdk:"timeouts"`
 }

--- a/internal/framework5provider/timeouts_resource_test.go
+++ b/internal/framework5provider/timeouts_resource_test.go
@@ -20,7 +20,6 @@ func TestTimeoutsResource_unconfigured(t *testing.T) {
 			{
 				Config: `resource "framework_timeouts" "test" {}`,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("framework_timeouts.test", "id", "test"),
 					resource.TestCheckNoResourceAttr("framework_timeouts.test", "timeouts"),
 				),
 			},
@@ -41,7 +40,6 @@ func TestTimeoutsResource_configured(t *testing.T) {
 					}
 				}`,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("framework_timeouts.test", "id", "test"),
 					resource.TestCheckResourceAttr("framework_timeouts.test", "timeouts.create", "120s"),
 				),
 			},

--- a/internal/framework6provider/float64_precision_resource.go
+++ b/internal/framework6provider/float64_precision_resource.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -30,13 +28,6 @@ func (r Float64PrecisionResource) Metadata(_ context.Context, req resource.Metad
 func (r Float64PrecisionResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			// id attribute is required for acceptance testing.
-			"id": schema.StringAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
 			"float64_attribute": schema.Float64Attribute{
 				Optional: true,
 				Computed: true,
@@ -56,7 +47,6 @@ func (r Float64PrecisionResource) Create(ctx context.Context, req resource.Creat
 
 	// Test semantic equality by losing the precision of the initial *big.Float
 	data.Float64Attribute = types.Float64Value(data.Float64Attribute.ValueFloat64())
-	data.Id = types.StringValue("test")
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -92,6 +82,5 @@ func (r Float64PrecisionResource) Delete(ctx context.Context, req resource.Delet
 }
 
 type Float64PrecisionResourceModel struct {
-	Id               types.String  `tfsdk:"id"`
 	Float64Attribute types.Float64 `tfsdk:"float64_attribute"`
 }

--- a/internal/framework6provider/resource_user.go
+++ b/internal/framework6provider/resource_user.go
@@ -48,10 +48,6 @@ func (r *resourceUser) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			"age": schema.NumberAttribute{
 				Required: true,
 			},
-			// included only for compatibility with SDKv2 test framework
-			"id": schema.StringAttribute{
-				Optional: true,
-			},
 			"date_joined": schema.StringAttribute{
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
@@ -86,7 +82,6 @@ type user struct {
 	Email      string       `tfsdk:"email"`
 	Name       string       `tfsdk:"name"`
 	Age        int          `tfsdk:"age"`
-	Id         string       `tfsdk:"id"`
 	DateJoined types.String `tfsdk:"date_joined"`
 	Language   types.String `tfsdk:"language"`
 }

--- a/internal/framework6provider/resource_user_test.go
+++ b/internal/framework6provider/resource_user_test.go
@@ -27,8 +27,6 @@ func TestAccFrameworkResourceUser(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"framework_user.foo", "age", "200"),
 					resource.TestCheckResourceAttr(
-						"framework_user.foo", "id", "h"),
-					resource.TestCheckResourceAttr(
 						"framework_user.foo", "language", "en"),
 				),
 			},
@@ -51,8 +49,6 @@ func TestAccFrameworkResourceUser_language(t *testing.T) {
 						"framework_user.foo", "email", "jdoe@example.com"),
 					resource.TestCheckResourceAttr(
 						"framework_user.foo", "age", "18"),
-					resource.TestCheckResourceAttr(
-						"framework_user.foo", "id", "jdoe"),
 					resource.TestCheckResourceAttr(
 						"framework_user.foo", "language", "es"),
 				),
@@ -82,8 +78,6 @@ func TestAccFrameworkResourceUser_interpolateLanguage(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"framework_user.foo", "age", "200"),
 					resource.TestCheckResourceAttr(
-						"framework_user.foo", "id", "h"),
-					resource.TestCheckResourceAttr(
 						"framework_user.foo", "language", "en"),
 				),
 			},
@@ -96,8 +90,6 @@ func TestAccFrameworkResourceUser_interpolateLanguage(t *testing.T) {
 						"framework_user.foo", "email", "ford@prefect.co"),
 					resource.TestCheckResourceAttr(
 						"framework_user.foo", "age", "200"),
-					resource.TestCheckResourceAttr(
-						"framework_user.foo", "id", "h"),
 					resource.TestCheckResourceAttr(
 						"framework_user.foo", "language", "es"),
 				),
@@ -127,7 +119,6 @@ resource "framework_user" "test" {
   email = "ford@prefect.co"
   name  = var.framework_user_name
   age   = 200
-  id    = "h"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -143,7 +134,6 @@ resource "framework_user" "foo" {
   email = "ford@prefect.co"
   name = "Ford Prefect"
   age = 200
-  id = "h"
 }
 `
 
@@ -152,7 +142,6 @@ resource "framework_user" "foo" {
   email = "jdoe@example.com"
   name = "J Doe"
   age = 18
-  id = "jdoe"
   language = "es"
 }
 `
@@ -167,7 +156,6 @@ resource "framework_user" "foo" {
   email = "ford@prefect.co"
   name = "Ford Prefect"
   age = 200
-  id = "h"
   language = random_shuffle.foo.result[0]
 }
 `

--- a/internal/framework6provider/timeouts_resource.go
+++ b/internal/framework6provider/timeouts_resource.go
@@ -9,9 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 var _ resource.Resource = TimeoutsResource{}
@@ -30,13 +27,6 @@ func (r TimeoutsResource) Metadata(_ context.Context, req resource.MetadataReque
 func (r TimeoutsResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			// id attribute is required for acceptance testing.
-			"id": schema.StringAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
 				Create: true,
 			}),
@@ -52,8 +42,6 @@ func (r TimeoutsResource) Create(ctx context.Context, req resource.CreateRequest
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	data.Id = types.StringValue("test")
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -86,6 +74,5 @@ func (r TimeoutsResource) Delete(ctx context.Context, req resource.DeleteRequest
 }
 
 type TimeoutsResourceModel struct {
-	Id       types.String   `tfsdk:"id"`
 	Timeouts timeouts.Value `tfsdk:"timeouts"`
 }

--- a/internal/framework6provider/timeouts_resource_test.go
+++ b/internal/framework6provider/timeouts_resource_test.go
@@ -20,7 +20,6 @@ func TestTimeoutsResource_unconfigured(t *testing.T) {
 			{
 				Config: `resource "framework_timeouts" "test" {}`,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("framework_timeouts.test", "id", "test"),
 					resource.TestCheckNoResourceAttr("framework_timeouts.test", "timeouts"),
 				),
 			},
@@ -41,7 +40,6 @@ func TestTimeoutsResource_configured(t *testing.T) {
 					}
 				}`,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("framework_timeouts.test", "id", "test"),
 					resource.TestCheckResourceAttr("framework_timeouts.test", "timeouts.create", "120s"),
 				),
 			},

--- a/internal/protocolprovider/data_time.go
+++ b/internal/protocolprovider/data_time.go
@@ -18,16 +18,13 @@ func (d dataSourceTime) ReadDataSource(ctx context.Context, req *tfprotov5.ReadD
 	state, err := tfprotov5.NewDynamicValue(tftypes.Object{
 		AttributeTypes: map[string]tftypes.Type{
 			"current": tftypes.String,
-			"id":      tftypes.String,
 		},
 	}, tftypes.NewValue(tftypes.Object{
 		AttributeTypes: map[string]tftypes.Type{
 			"current": tftypes.String,
-			"id":      tftypes.String,
 		},
 	}, map[string]tftypes.Value{
 		"current": tftypes.NewValue(tftypes.String, time.Now().Format(time.RFC3339)),
-		"id":      tftypes.NewValue(tftypes.String, "static_id"),
 	}))
 	if err != nil {
 		return &tfprotov5.ReadDataSourceResponse{

--- a/internal/protocolprovider/server.go
+++ b/internal/protocolprovider/server.go
@@ -108,12 +108,6 @@ func Server() tfprotov5.ProviderServer {
 							DescriptionKind: tfprotov5.StringKindPlain,
 							Computed:        true,
 						},
-						{
-							Name:     "id",
-							Type:     tftypes.String,
-							Optional: true,
-							Computed: true,
-						},
 					},
 				},
 			},

--- a/internal/protocolv6provider/data_time.go
+++ b/internal/protocolv6provider/data_time.go
@@ -18,16 +18,13 @@ func (d dataSourceTime) ReadDataSource(ctx context.Context, req *tfprotov6.ReadD
 	state, err := tfprotov6.NewDynamicValue(tftypes.Object{
 		AttributeTypes: map[string]tftypes.Type{
 			"current": tftypes.String,
-			"id":      tftypes.String,
 		},
 	}, tftypes.NewValue(tftypes.Object{
 		AttributeTypes: map[string]tftypes.Type{
 			"current": tftypes.String,
-			"id":      tftypes.String,
 		},
 	}, map[string]tftypes.Value{
 		"current": tftypes.NewValue(tftypes.String, time.Now().Format(time.RFC3339)),
-		"id":      tftypes.NewValue(tftypes.String, "static_id"),
 	}))
 	if err != nil {
 		return &tfprotov6.ReadDataSourceResponse{

--- a/internal/protocolv6provider/server.go
+++ b/internal/protocolv6provider/server.go
@@ -108,12 +108,6 @@ func Server() tfprotov6.ProviderServer {
 							DescriptionKind: tfprotov6.StringKindPlain,
 							Computed:        true,
 						},
-						{
-							Name:     "id",
-							Type:     tftypes.String,
-							Optional: true,
-							Computed: true,
-						},
 					},
 				},
 			},

--- a/internal/tf6muxprovider/provider1/resource_user.go
+++ b/internal/tf6muxprovider/provider1/resource_user.go
@@ -48,10 +48,6 @@ func (r *resourceUser) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			"age": schema.NumberAttribute{
 				Required: true,
 			},
-			// included only for compatibility with SDKv2 test framework
-			"id": schema.StringAttribute{
-				Optional: true,
-			},
 			"date_joined": schema.StringAttribute{
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
@@ -86,7 +82,6 @@ type user struct {
 	Email      string       `tfsdk:"email"`
 	Name       string       `tfsdk:"name"`
 	Age        int          `tfsdk:"age"`
-	Id         string       `tfsdk:"id"`
 	DateJoined types.String `tfsdk:"date_joined"`
 	Language   types.String `tfsdk:"language"`
 }

--- a/internal/tf6muxprovider/provider1/resource_user_test.go
+++ b/internal/tf6muxprovider/provider1/resource_user_test.go
@@ -22,7 +22,6 @@ func TestAccResourceUser1(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("tf6muxprovider_user1.example", "age", "123"),
 					resource.TestCheckResourceAttr("tf6muxprovider_user1.example", "email", "example@example.com"),
-					resource.TestCheckResourceAttr("tf6muxprovider_user1.example", "id", "h"),
 					resource.TestCheckResourceAttr("tf6muxprovider_user1.example", "language", "en"),
 					resource.TestCheckResourceAttr("tf6muxprovider_user1.example", "name", "Example Name"),
 				),
@@ -35,7 +34,6 @@ const configResourceUserBasic = `
 resource "tf6muxprovider_user1" "example" {
   age   = 123
   email = "example@example.com"
-  id    = "h"
   name  = "Example Name"
 }
 `

--- a/internal/tf6muxprovider/provider2/resource_user.go
+++ b/internal/tf6muxprovider/provider2/resource_user.go
@@ -48,10 +48,6 @@ func (r *resourceUser) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			"age": schema.NumberAttribute{
 				Required: true,
 			},
-			// included only for compatibility with SDKv2 test framework
-			"id": schema.StringAttribute{
-				Optional: true,
-			},
 			"date_joined": schema.StringAttribute{
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
@@ -86,7 +82,6 @@ type user struct {
 	Email      string       `tfsdk:"email"`
 	Name       string       `tfsdk:"name"`
 	Age        int          `tfsdk:"age"`
-	Id         string       `tfsdk:"id"`
 	DateJoined types.String `tfsdk:"date_joined"`
 	Language   types.String `tfsdk:"language"`
 }

--- a/internal/tf6muxprovider/provider2/resource_user_test.go
+++ b/internal/tf6muxprovider/provider2/resource_user_test.go
@@ -22,7 +22,6 @@ func TestAccResourceUser2(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("tf6muxprovider_user2.example", "age", "123"),
 					resource.TestCheckResourceAttr("tf6muxprovider_user2.example", "email", "example@example.com"),
-					resource.TestCheckResourceAttr("tf6muxprovider_user2.example", "id", "h"),
 					resource.TestCheckResourceAttr("tf6muxprovider_user2.example", "language", "en"),
 					resource.TestCheckResourceAttr("tf6muxprovider_user2.example", "name", "Example Name"),
 				),
@@ -35,7 +34,6 @@ const configResourceUserBasic = `
 resource "tf6muxprovider_user2" "example" {
   age   = 123
   email = "example@example.com"
-  id    = "h"
   name  = "Example Name"
 }
 `

--- a/internal/tf6muxprovider/provider_test.go
+++ b/internal/tf6muxprovider/provider_test.go
@@ -28,12 +28,10 @@ func TestAccResourceUser(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("tf6muxprovider_user1.example", "age", "123"),
 					resource.TestCheckResourceAttr("tf6muxprovider_user1.example", "email", "example1@example.com"),
-					resource.TestCheckResourceAttr("tf6muxprovider_user1.example", "id", "h"),
 					resource.TestCheckResourceAttr("tf6muxprovider_user1.example", "language", "en"),
 					resource.TestCheckResourceAttr("tf6muxprovider_user1.example", "name", "Example Name 1"),
 					resource.TestCheckResourceAttr("tf6muxprovider_user2.example", "age", "234"),
 					resource.TestCheckResourceAttr("tf6muxprovider_user2.example", "email", "example2@example.com"),
-					resource.TestCheckResourceAttr("tf6muxprovider_user2.example", "id", "h"),
 					resource.TestCheckResourceAttr("tf6muxprovider_user2.example", "language", "en"),
 					resource.TestCheckResourceAttr("tf6muxprovider_user2.example", "name", "Example Name 2"),
 				),
@@ -46,14 +44,12 @@ const configResourceUserBasic = `
 resource "tf6muxprovider_user1" "example" {
   age   = 123
   email = "example1@example.com"
-  id    = "h"
   name  = "Example Name 1"
 }
 
 resource "tf6muxprovider_user2" "example" {
   age   = 234
   email = "example2@example.com"
-  id    = "h"
   name  = "Example Name 2"
 }
 `

--- a/internal/tf6to5provider/provider/resource_user.go
+++ b/internal/tf6to5provider/provider/resource_user.go
@@ -48,10 +48,6 @@ func (r *resourceUser) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			"age": schema.NumberAttribute{
 				Required: true,
 			},
-			// included only for compatibility with SDKv2 test framework
-			"id": schema.StringAttribute{
-				Optional: true,
-			},
 			"date_joined": schema.StringAttribute{
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
@@ -86,7 +82,6 @@ type user struct {
 	Email      string       `tfsdk:"email"`
 	Name       string       `tfsdk:"name"`
 	Age        int          `tfsdk:"age"`
-	Id         string       `tfsdk:"id"`
 	DateJoined types.String `tfsdk:"date_joined"`
 	Language   types.String `tfsdk:"language"`
 }

--- a/internal/tf6to5provider/provider/resource_user_test.go
+++ b/internal/tf6to5provider/provider/resource_user_test.go
@@ -22,7 +22,6 @@ func TestAccResourceUser(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("tf6to5provider_user.example", "age", "123"),
 					resource.TestCheckResourceAttr("tf6to5provider_user.example", "email", "example@example.com"),
-					resource.TestCheckResourceAttr("tf6to5provider_user.example", "id", "h"),
 					resource.TestCheckResourceAttr("tf6to5provider_user.example", "language", "en"),
 					resource.TestCheckResourceAttr("tf6to5provider_user.example", "name", "Example Name"),
 				),
@@ -35,7 +34,6 @@ const configResourceUserBasic = `
 resource "tf6to5provider_user" "example" {
   age   = 123
   email = "example@example.com"
-  id    = "h"
   name  = "Example Name"
 }
 `

--- a/internal/tf6to5provider/provider_test.go
+++ b/internal/tf6to5provider/provider_test.go
@@ -28,7 +28,6 @@ func TestAccResourceUser(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("tf6to5provider_user.example", "age", "123"),
 					resource.TestCheckResourceAttr("tf6to5provider_user.example", "email", "example@example.com"),
-					resource.TestCheckResourceAttr("tf6to5provider_user.example", "id", "h"),
 					resource.TestCheckResourceAttr("tf6to5provider_user.example", "language", "en"),
 					resource.TestCheckResourceAttr("tf6to5provider_user.example", "name", "Example Name"),
 				),
@@ -41,7 +40,6 @@ const configResourceUserBasic = `
 resource "tf6to5provider_user" "example" {
   age   = 123
   email = "example@example.com"
-  id    = "h"
   name  = "Example Name"
 }
 `


### PR DESCRIPTION
Ref: https://github.com/hashicorp/terraform-plugin-testing/issues/84

This PR removes the `id` attribute from all resource tests as it's no longer required after `terraform-plugin-testing v1.5.0`