### PR TITLE
Add terraform-plugin-framework-timetypes smoke testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hashicorp/terraform-json v0.22.1
 	github.com/hashicorp/terraform-plugin-framework v1.8.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1
+	github.com/hashicorp/terraform-plugin-framework-timetypes v0.3.1-0.20240603201021-7bd32fff99cf
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-mux v0.16.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-json v0.22.1
 	github.com/hashicorp/terraform-plugin-framework v1.8.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1
-	github.com/hashicorp/terraform-plugin-framework-timetypes v0.3.1-0.20240603201021-7bd32fff99cf
+	github.com/hashicorp/terraform-plugin-framework-timetypes v0.4.0
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-mux v0.16.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/hashicorp/terraform-plugin-framework v1.8.0 h1:P07qy8RKLcoBkCrY2RHJer
 github.com/hashicorp/terraform-plugin-framework v1.8.0/go.mod h1:/CpTukO88PcL/62noU7cuyaSJ4Rsim+A/pa+3rUVufY=
 github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1 h1:gm5b1kHgFFhaKFhm4h2TgvMUlNzFAtUqlcOWnWPm+9E=
 github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1/go.mod h1:MsjL1sQ9L7wGwzJ5RjcI6FzEMdyoBnw+XK8ZnOvQOLY=
+github.com/hashicorp/terraform-plugin-framework-timetypes v0.3.1-0.20240603201021-7bd32fff99cf h1:R8f1PhJW+td+HbzAptBWyCzHOGIIW/DiEOIuAqk4og4=
+github.com/hashicorp/terraform-plugin-framework-timetypes v0.3.1-0.20240603201021-7bd32fff99cf/go.mod h1:mGuieb3bqKFYwEYB4lCMt302Z3siyv4PFYk/41wAUps=
 github.com/hashicorp/terraform-plugin-go v0.23.0 h1:AALVuU1gD1kPb48aPQUjug9Ir/125t+AAurhqphJ2Co=
 github.com/hashicorp/terraform-plugin-go v0.23.0/go.mod h1:1E3Cr9h2vMlahWMbsSEcNrOCxovCZhOOIXjFHbjc/lQ=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/hashicorp/terraform-plugin-framework v1.8.0 h1:P07qy8RKLcoBkCrY2RHJer
 github.com/hashicorp/terraform-plugin-framework v1.8.0/go.mod h1:/CpTukO88PcL/62noU7cuyaSJ4Rsim+A/pa+3rUVufY=
 github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1 h1:gm5b1kHgFFhaKFhm4h2TgvMUlNzFAtUqlcOWnWPm+9E=
 github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1/go.mod h1:MsjL1sQ9L7wGwzJ5RjcI6FzEMdyoBnw+XK8ZnOvQOLY=
-github.com/hashicorp/terraform-plugin-framework-timetypes v0.3.1-0.20240603201021-7bd32fff99cf h1:R8f1PhJW+td+HbzAptBWyCzHOGIIW/DiEOIuAqk4og4=
-github.com/hashicorp/terraform-plugin-framework-timetypes v0.3.1-0.20240603201021-7bd32fff99cf/go.mod h1:mGuieb3bqKFYwEYB4lCMt302Z3siyv4PFYk/41wAUps=
+github.com/hashicorp/terraform-plugin-framework-timetypes v0.4.0 h1:XLI93Oqw2/KTzYjgCXrUnm8LBkGAiHC/mDQg5g5Vob4=
+github.com/hashicorp/terraform-plugin-framework-timetypes v0.4.0/go.mod h1:mGuieb3bqKFYwEYB4lCMt302Z3siyv4PFYk/41wAUps=
 github.com/hashicorp/terraform-plugin-go v0.23.0 h1:AALVuU1gD1kPb48aPQUjug9Ir/125t+AAurhqphJ2Co=
 github.com/hashicorp/terraform-plugin-go v0.23.0/go.mod h1:1E3Cr9h2vMlahWMbsSEcNrOCxovCZhOOIXjFHbjc/lQ=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=

--- a/internal/framework5provider/provider.go
+++ b/internal/framework5provider/provider.go
@@ -53,6 +53,7 @@ func (p *testProvider) Resources(_ context.Context) []func() resource.Resource {
 		NewDynamicSchemaResource,
 		NewDynamicComputedTypeChangeResource,
 		NewTimeoutsResource,
+		NewTimeTypesResource,
 		NewUserResource,
 		NewFloat64PrecisionResource,
 	}

--- a/internal/framework5provider/timetypes_resource.go
+++ b/internal/framework5provider/timetypes_resource.go
@@ -1,0 +1,84 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package framework
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+var _ resource.Resource = TimeTypesResource{}
+
+func NewTimeTypesResource() resource.Resource {
+	return &TimeTypesResource{}
+}
+
+// TimeTypesResource is for testing all schema types.
+type TimeTypesResource struct{}
+
+func (r TimeTypesResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_timetypes"
+}
+
+func (r TimeTypesResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"go_duration": schema.StringAttribute{
+				CustomType: timetypes.GoDurationType{},
+				Optional:   true,
+			},
+			"rfc3339": schema.StringAttribute{
+				CustomType: timetypes.RFC3339Type{},
+				Optional:   true,
+			},
+		},
+	}
+}
+
+func (r TimeTypesResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data TimeTypesResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r TimeTypesResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data TimeTypesResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r TimeTypesResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data TimeTypesResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r TimeTypesResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+}
+
+type TimeTypesResourceModel struct {
+	GoDuration timetypes.GoDuration `tfsdk:"go_duration"`
+	Rfc3339    timetypes.RFC3339    `tfsdk:"rfc3339"`
+}

--- a/internal/framework5provider/timetypes_resource_test.go
+++ b/internal/framework5provider/timetypes_resource_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package framework
 
 import (

--- a/internal/framework5provider/timetypes_resource_test.go
+++ b/internal/framework5provider/timetypes_resource_test.go
@@ -1,0 +1,106 @@
+package framework
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestTimeTypesResource_Null(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
+			"framework": providerserver.NewProtocol5WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_timetypes" "test" {}`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("framework_timetypes.test", tfjsonpath.New("go_duration"), knownvalue.Null()),
+					statecheck.ExpectKnownValue("framework_timetypes.test", tfjsonpath.New("rfc3339"), knownvalue.Null()),
+				},
+			},
+		},
+	})
+}
+
+func TestTimeTypesResource_GoDuration_Valid(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
+			"framework": providerserver.NewProtocol5WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "framework_timetypes" "test" {
+  go_duration = "1h2m3s"
+}
+`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("framework_timetypes.test", tfjsonpath.New("go_duration"), knownvalue.StringExact("1h2m3s")),
+				},
+			},
+		},
+	})
+}
+
+func TestTimeTypesResource_GoDuration_Invalid(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
+			"framework": providerserver.NewProtocol5WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "framework_timetypes" "test" {
+  go_duration = "invalid"
+}
+`,
+				ExpectError: regexp.MustCompile(`Invalid Time Duration String Value`),
+			},
+		},
+	})
+}
+
+func TestTimeTypesResource_RFC3339_Valid(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
+			"framework": providerserver.NewProtocol5WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "framework_timetypes" "test" {
+  rfc3339 = "2000-01-02T03:04:05Z"
+}
+`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("framework_timetypes.test", tfjsonpath.New("rfc3339"), knownvalue.StringExact("2000-01-02T03:04:05Z")),
+				},
+			},
+		},
+	})
+}
+
+func TestTimeTypesResource_RFC3339_Invalid(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
+			"framework": providerserver.NewProtocol5WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "framework_timetypes" "test" {
+  rfc3339 = "invalid"
+}
+`,
+				ExpectError: regexp.MustCompile(`Invalid RFC3339 String Value`),
+			},
+		},
+	})
+}

--- a/internal/framework6provider/provider.go
+++ b/internal/framework6provider/provider.go
@@ -52,6 +52,7 @@ func (p *testProvider) Resources(_ context.Context) []func() resource.Resource {
 		NewSchemaResource,
 		NewDynamicComputedTypeChangeResource,
 		NewTimeoutsResource,
+		NewTimeTypesResource,
 		NewUserResource,
 		NewFloat64PrecisionResource,
 	}

--- a/internal/framework6provider/timetypes_resource.go
+++ b/internal/framework6provider/timetypes_resource.go
@@ -1,0 +1,84 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package framework
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+var _ resource.Resource = TimeTypesResource{}
+
+func NewTimeTypesResource() resource.Resource {
+	return &TimeTypesResource{}
+}
+
+// TimeTypesResource is for testing all schema types.
+type TimeTypesResource struct{}
+
+func (r TimeTypesResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_timetypes"
+}
+
+func (r TimeTypesResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"go_duration": schema.StringAttribute{
+				CustomType: timetypes.GoDurationType{},
+				Optional:   true,
+			},
+			"rfc3339": schema.StringAttribute{
+				CustomType: timetypes.RFC3339Type{},
+				Optional:   true,
+			},
+		},
+	}
+}
+
+func (r TimeTypesResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data TimeTypesResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r TimeTypesResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data TimeTypesResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r TimeTypesResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data TimeTypesResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r TimeTypesResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+}
+
+type TimeTypesResourceModel struct {
+	GoDuration timetypes.GoDuration `tfsdk:"go_duration"`
+	Rfc3339    timetypes.RFC3339    `tfsdk:"rfc3339"`
+}

--- a/internal/framework6provider/timetypes_resource_test.go
+++ b/internal/framework6provider/timetypes_resource_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package framework
 
 import (

--- a/internal/framework6provider/timetypes_resource_test.go
+++ b/internal/framework6provider/timetypes_resource_test.go
@@ -1,0 +1,106 @@
+package framework
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestTimeTypesResource_Null(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_timetypes" "test" {}`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("framework_timetypes.test", tfjsonpath.New("go_duration"), knownvalue.Null()),
+					statecheck.ExpectKnownValue("framework_timetypes.test", tfjsonpath.New("rfc3339"), knownvalue.Null()),
+				},
+			},
+		},
+	})
+}
+
+func TestTimeTypesResource_GoDuration_Valid(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "framework_timetypes" "test" {
+  go_duration = "1h2m3s"
+}
+`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("framework_timetypes.test", tfjsonpath.New("go_duration"), knownvalue.StringExact("1h2m3s")),
+				},
+			},
+		},
+	})
+}
+
+func TestTimeTypesResource_GoDuration_Invalid(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "framework_timetypes" "test" {
+  go_duration = "invalid"
+}
+`,
+				ExpectError: regexp.MustCompile(`Invalid Time Duration String Value`),
+			},
+		},
+	})
+}
+
+func TestTimeTypesResource_RFC3339_Valid(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "framework_timetypes" "test" {
+  rfc3339 = "2000-01-02T03:04:05Z"
+}
+`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("framework_timetypes.test", tfjsonpath.New("rfc3339"), knownvalue.StringExact("2000-01-02T03:04:05Z")),
+				},
+			},
+		},
+	})
+}
+
+func TestTimeTypesResource_RFC3339_Invalid(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "framework_timetypes" "test" {
+  rfc3339 = "invalid"
+}
+`,
+				ExpectError: regexp.MustCompile(`Invalid RFC3339 String Value`),
+			},
+		},
+	})
+}


### PR DESCRIPTION
The `timetypes` library is being extended with new Go `time.Duration` types, so now seems a good as a time as any to ensure there is some lightweight integration testing of terraform-plugin-framework-timetypes. That Go module could reach out to this testing similar to the Continuous Integration setup of terraform-plugin-go and other plugin Go modules.