### PR TITLE
all: Bump minimum Go module version to 1.22

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - forcetypeassert
     - gofmt
     - gosimple
+    - govet
     - ineffassign
     - makezero
     - misspell
@@ -21,7 +22,6 @@ linters:
     - unconvert
     - unparam
     - unused
-    - vet
 
 run:
   # Prevent false positive timeouts in CI

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/hashicorp/terraform-provider-corner
 
-go 1.21
-
-toolchain go1.21.6
+go 1.22.7
 
 require (
 	github.com/hashicorp/go-memdb v1.3.4

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.21
+go 1.22.7
 
 require github.com/hashicorp/copywrite v0.19.0
 


### PR DESCRIPTION
Ref: https://github.com/hashicorp/terraform-providers-devex-internal/issues/182

Bumps the Go module to 1.22.7, all workflows just use the `go.mod` file to get this version info