### PR TITLE
chore: Fix provider schema to allow muxing

### DIFF
--- a/internal/protocolprovider/server.go
+++ b/internal/protocolprovider/server.go
@@ -143,7 +143,15 @@ func (s *server) CloseEphemeralResource(context.Context, *tfprotov5.CloseEphemer
 func Server() tfprotov5.ProviderServer {
 	return &server{
 		providerSchema: &tfprotov5.Schema{
-			Block: &tfprotov5.SchemaBlock{},
+			Block: &tfprotov5.SchemaBlock{
+				Attributes: []*tfprotov5.SchemaAttribute{
+					{
+						Name:     "deferral",
+						Type:     tftypes.Bool,
+						Optional: true,
+					},
+				},
+			},
 		},
 		dataSourceSchemas: map[string]*tfprotov5.Schema{
 			"corner_time": {


### PR DESCRIPTION
This resolves a muxing error when executing the provider directly (via debugging for example)

```bash
│ Error: Failed to load plugin schemas
│ 
│ Error while loading schemas for plugin components: Failed to obtain provider schema: Could not load the schema for provider registry.terraform.io/hashicorp/corner: failed to retrieve schema from provider
│ "registry.terraform.io/hashicorp/corner": Invalid Provider Server Combination: The combined provider has differing provider schema implementations across providers. Provider schemas must be identical across providers. This
│ is always an issue in the provider implementation and should be reported to the provider developers.
│ 
│ Provider schema difference:   &tfprotov5.Schema{
│       Version: 0,
│       Block: &tfprotov5.SchemaBlock{
│               Version:     0,
│ -             Attributes:  []*tfprotov5.SchemaAttribute{&{Name: "deferral", Type: s"tftypes.Bool", Optional: true}},
│ +             Attributes:  []*tfprotov5.SchemaAttribute{},
│               BlockTypes:  nil,
│               Description: "",
│               ... // 2 identical fields
│       },
│   }
│ ..
```