### PR TITLE
Dependabot: Single weekly PR for GH Actions, Single PR for terraform-plugin-* Go dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      # Group all terraform-plugin-(go|sdk|framework|testing) dependencies together
+      "terraform-plugin":
+        patterns:
+          - "github.com/hashicorp/terraform-plugin-*"
   - package-ecosystem: "gomod"
     directory: "/tools"
     schedule:


### PR DESCRIPTION

This PR changes the interval for GH Actions updates to a single weekly PR on Mondays at 9am UTC. It also groups all GH Actions updates into a single PR to make it easier for us to review and merge changes across the 30+ repositories we maintain.

Furthermore, this PR starts grouping all terraform-plugin-* Go dependency updates into a single PR as we usually release them (`terraform-plugin-(go|sdk|framework|testing)`) together.


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>