### PR TITLE
Add framework tests for unlinked actions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-memdb v1.3.5
+	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-json v0.25.0
 	github.com/hashicorp/terraform-plugin-framework v1.16.0-beta.1
 	github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0
@@ -36,7 +37,6 @@ require (
 	github.com/hashicorp/go-plugin v1.6.3 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
-	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hc-install v0.9.2 // indirect
 	github.com/hashicorp/hcl/v2 v2.23.0 // indirect

--- a/internal/framework5provider/provider.go
+++ b/internal/framework5provider/provider.go
@@ -6,6 +6,7 @@ package framework
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/action"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
 	"github.com/hashicorp/terraform-plugin-framework/function"
@@ -150,6 +151,12 @@ func (p *testProvider) EphemeralResources(ctx context.Context) []func() ephemera
 func (p *testProvider) ListResources(_ context.Context) []func() list.ListResource {
 	return []func() list.ListResource{
 		NewListResourceAsListResource,
+	}
+}
+
+func (p *testProvider) Actions(ctx context.Context) []func() action.Action {
+	return []func() action.Action{
+		NewUnlinkedAction,
 	}
 }
 

--- a/internal/framework5provider/unlinked_action.go
+++ b/internal/framework5provider/unlinked_action.go
@@ -1,0 +1,98 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package framework
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/terraform-plugin-framework/action"
+	"github.com/hashicorp/terraform-plugin-framework/action/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+var _ action.Action = &UnlinkedAction{}
+var _ action.ActionWithModifyPlan = &UnlinkedAction{}
+
+func NewUnlinkedAction() action.Action {
+	return &UnlinkedAction{}
+}
+
+type UnlinkedAction struct{}
+
+func (u *UnlinkedAction) Schema(ctx context.Context, req action.SchemaRequest, resp *action.SchemaResponse) {
+	resp.Schema = schema.UnlinkedSchema{
+		Attributes: map[string]schema.Attribute{
+			"filename": schema.StringAttribute{
+				Required: true,
+			},
+			"content": schema.StringAttribute{
+				Required: true,
+			},
+			"plan_error": schema.BoolAttribute{
+				Optional: true,
+			},
+		},
+	}
+}
+
+func (u *UnlinkedAction) Metadata(ctx context.Context, req action.MetadataRequest, resp *action.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_unlinked_action"
+}
+
+func (u *UnlinkedAction) ModifyPlan(ctx context.Context, req action.ModifyPlanRequest, resp *action.ModifyPlanResponse) {
+	if req.Config.Raw.IsNull() {
+		return
+	}
+
+	var planError *bool
+
+	diags := req.Config.GetAttribute(ctx, path.Root("plan_error"), &planError)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if planError != nil && *planError {
+		resp.Diagnostics.AddError("ModifyPlan error", "plan_error attribute was set to true")
+		return
+	}
+}
+
+func (u *UnlinkedAction) Invoke(ctx context.Context, req action.InvokeRequest, resp *action.InvokeResponse) {
+	resp.SendProgress = func(event action.InvokeProgressEvent) {
+		event.Message = "starting provider defined unlinked action"
+	}
+
+	var filename string
+	var content string
+
+	diags := req.Config.GetAttribute(ctx, path.Root("filename"), &filename)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	diags = req.Config.GetAttribute(ctx, path.Root("content"), &content)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	fi, err := os.Create(filename)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating file", fmt.Sprintf("There was an error creating the file %s: "+
+			"original error %s", filename, err))
+		return
+	}
+
+	_, err = fi.Write([]byte(content))
+	if err != nil {
+		resp.Diagnostics.AddError("Error writing to file", fmt.Sprintf("There was an error writing to file %s: "+
+			"original error %s", filename, err))
+		return
+	}
+
+}

--- a/internal/framework5provider/unlinked_action_test.go
+++ b/internal/framework5provider/unlinked_action_test.go
@@ -1,0 +1,206 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package framework
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+)
+
+func TestUnlinkedAction(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "local_file")
+	f = strings.ReplaceAll(f, `\`, `\\`)
+
+	content := "test data"
+	updatedContent := "updated test data"
+
+	resource.UnitTest(t, resource.TestCase{
+
+		// Unlinked Actions are only available in 1.14.0+
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.14.0"))),
+		},
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "terraform_data" "test" {
+					input = "fake-string"
+
+					lifecycle {
+						action_trigger {
+						  events  = [before_create]
+						  actions = [action.framework_unlinked_action.file]
+						}
+					}
+				}
+
+				action "framework_unlinked_action" "file" {
+					config {
+						filename = %[1]q
+						content  = %[2]q
+					}
+				  
+				}`, f, content),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("terraform_data.test", plancheck.ResourceActionCreate),
+						plancheck.ExpectKnownValue("terraform_data.test", tfjsonpath.New("input"), knownvalue.StringExact("fake-string")),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("terraform_data.test", tfjsonpath.New("input"), knownvalue.StringExact("fake-string")),
+				},
+				Check: func(state *terraform.State) error {
+					resultContent, err := os.ReadFile(f)
+					if err != nil {
+						return fmt.Errorf("Error occurred while reading file at path: %s\n, error: %s\n", f, err)
+					}
+
+					if string(resultContent) != content {
+						return fmt.Errorf("Expected file content %s\n, got: %s\n", content, resultContent)
+					}
+					return nil
+				},
+			},
+			// Test that changing the action configuration by itself doesn't invoke the action
+			{
+				Config: fmt.Sprintf(`
+				resource "terraform_data" "test" {
+					input = "fake-string"
+
+					lifecycle {
+						action_trigger {
+						  events  = [before_create]
+						  actions = [action.framework_unlinked_action.file]
+						}
+					}
+				}
+
+				action "framework_unlinked_action" "file" {
+					config {
+						filename = %[1]q
+						content  = "updated test data"
+					}
+				  
+				}`, f),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("terraform_data.test", plancheck.ResourceActionNoop),
+						plancheck.ExpectKnownValue("terraform_data.test", tfjsonpath.New("input"), knownvalue.StringExact("fake-string")),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("terraform_data.test", tfjsonpath.New("input"), knownvalue.StringExact("fake-string")),
+				},
+				Check: func(state *terraform.State) error {
+					resultContent, err := os.ReadFile(f)
+					if err != nil {
+						return fmt.Errorf("Error occurred while reading file at path: %s\n, error: %s\n", f, err)
+					}
+
+					if string(resultContent) != content {
+						return fmt.Errorf("Expected file content %s\n, got: %s\n", content, resultContent)
+					}
+					return nil
+				},
+			},
+			// test an 'after_update' event
+			{
+				Config: fmt.Sprintf(`
+				resource "terraform_data" "test" {
+					input = "updated-fake-string" # trigger an update
+			
+					lifecycle {
+						action_trigger {
+						  events  = [after_update] # action triggers after update
+						  actions = [action.framework_unlinked_action.file]
+						}
+					}
+				}
+
+				action "framework_unlinked_action" "file" {
+					config {
+						filename = %[1]q
+						content  = "updated test data"
+					}
+				  
+				}`, f),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("terraform_data.test", plancheck.ResourceActionUpdate),
+						plancheck.ExpectKnownValue("terraform_data.test", tfjsonpath.New("input"), knownvalue.StringExact("updated-fake-string")),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("terraform_data.test", tfjsonpath.New("input"), knownvalue.StringExact("updated-fake-string")),
+				},
+				Check: func(state *terraform.State) error {
+					resultContent, err := os.ReadFile(f)
+					if err != nil {
+						return fmt.Errorf("Error occurred while reading file at path: %s\n, error: %s\n", f, err)
+					}
+
+					if string(resultContent) != updatedContent {
+						return fmt.Errorf("Expected file content %s\n, got: %s\n", updatedContent, resultContent)
+					}
+					return nil
+				},
+			},
+			// Test Plan Modification
+			{
+				Config: fmt.Sprintf(`
+				resource "terraform_data" "test" {
+					input = "fake-strings" # trigger an update
+			
+					lifecycle {
+						action_trigger {
+						  events  = [after_update]
+						  actions = [action.framework_unlinked_action.file]
+						}
+					}
+				}
+			
+				action "framework_unlinked_action" "file" {
+					config {
+						filename = %[1]q
+						content  = %[2]q
+						plan_error = true
+					}
+			
+				}`, f, content),
+				ExpectError: regexp.MustCompile("ModifyPlan error"),
+				// Assert that the file remains unchanged
+				Check: func(state *terraform.State) error {
+					resultContent, err := os.ReadFile(f)
+					if err != nil {
+						return fmt.Errorf("Error occurred while reading file at path: %s\n, error: %s\n", f, err)
+					}
+
+					if string(resultContent) != updatedContent {
+						return fmt.Errorf("Expected file content %s\n, got: %s\n", updatedContent, resultContent)
+					}
+					return nil
+				},
+			},
+		},
+	})
+}

--- a/internal/framework6provider/provider.go
+++ b/internal/framework6provider/provider.go
@@ -6,6 +6,7 @@ package framework
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/action"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
 	"github.com/hashicorp/terraform-plugin-framework/function"
@@ -20,6 +21,7 @@ import (
 var (
 	_ provider.ProviderWithFunctions          = (*testProvider)(nil)
 	_ provider.ProviderWithEphemeralResources = (*testProvider)(nil)
+	_ provider.ProviderWithActions            = (*testProvider)(nil)
 )
 
 func New() provider.Provider {
@@ -141,6 +143,12 @@ func (p *testProvider) EphemeralResources(ctx context.Context) []func() ephemera
 	return []func() ephemeral.EphemeralResource{
 		NewSchemaEphemeralResource,
 		NewEphemeralLifecycleResource,
+	}
+}
+
+func (p *testProvider) Actions(ctx context.Context) []func() action.Action {
+	return []func() action.Action{
+		NewUnlinkedAction,
 	}
 }
 

--- a/internal/framework6provider/unlinked_action.go
+++ b/internal/framework6provider/unlinked_action.go
@@ -1,0 +1,98 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package framework
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/terraform-plugin-framework/action"
+	"github.com/hashicorp/terraform-plugin-framework/action/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+var _ action.Action = &UnlinkedAction{}
+var _ action.ActionWithModifyPlan = &UnlinkedAction{}
+
+func NewUnlinkedAction() action.Action {
+	return &UnlinkedAction{}
+}
+
+type UnlinkedAction struct{}
+
+func (u *UnlinkedAction) Schema(ctx context.Context, req action.SchemaRequest, resp *action.SchemaResponse) {
+	resp.Schema = schema.UnlinkedSchema{
+		Attributes: map[string]schema.Attribute{
+			"filename": schema.StringAttribute{
+				Required: true,
+			},
+			"content": schema.StringAttribute{
+				Required: true,
+			},
+			"plan_error": schema.BoolAttribute{
+				Optional: true,
+			},
+		},
+	}
+}
+
+func (u *UnlinkedAction) Metadata(ctx context.Context, req action.MetadataRequest, resp *action.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_unlinked_action"
+}
+
+func (u *UnlinkedAction) ModifyPlan(ctx context.Context, req action.ModifyPlanRequest, resp *action.ModifyPlanResponse) {
+	if req.Config.Raw.IsNull() {
+		return
+	}
+
+	var planError *bool
+
+	diags := req.Config.GetAttribute(ctx, path.Root("plan_error"), &planError)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if planError != nil && *planError {
+		resp.Diagnostics.AddError("ModifyPlan error", "plan_error attribute was set to true")
+		return
+	}
+}
+
+func (u *UnlinkedAction) Invoke(ctx context.Context, req action.InvokeRequest, resp *action.InvokeResponse) {
+	resp.SendProgress = func(event action.InvokeProgressEvent) {
+		event.Message = "starting provider defined unlinked action"
+	}
+
+	var filename string
+	var content string
+
+	diags := req.Config.GetAttribute(ctx, path.Root("filename"), &filename)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	diags = req.Config.GetAttribute(ctx, path.Root("content"), &content)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	fi, err := os.Create(filename)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating file", fmt.Sprintf("There was an error creating the file %s: "+
+			"original error %s", filename, err))
+		return
+	}
+
+	_, err = fi.Write([]byte(content))
+	if err != nil {
+		resp.Diagnostics.AddError("Error writing to file", fmt.Sprintf("There was an error writing to file %s: "+
+			"original error %s", filename, err))
+		return
+	}
+
+}

--- a/internal/framework6provider/unlinked_action_test.go
+++ b/internal/framework6provider/unlinked_action_test.go
@@ -1,0 +1,206 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package framework
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+)
+
+func TestUnlinkedAction(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "local_file")
+	f = strings.ReplaceAll(f, `\`, `\\`)
+
+	content := "test data"
+	updatedContent := "updated test data"
+
+	resource.UnitTest(t, resource.TestCase{
+
+		// Unlinked Actions are only available in 1.14.0+
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.14.0"))),
+		},
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"framework": providerserver.NewProtocol6WithError(New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "terraform_data" "test" {
+					input = "fake-string"
+
+					lifecycle {
+						action_trigger {
+						  events  = [before_create]
+						  actions = [action.framework_unlinked_action.file]
+						}
+					}
+				}
+
+				action "framework_unlinked_action" "file" {
+					config {
+						filename = %[1]q
+						content  = %[2]q
+					}
+				  
+				}`, f, content),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("terraform_data.test", plancheck.ResourceActionCreate),
+						plancheck.ExpectKnownValue("terraform_data.test", tfjsonpath.New("input"), knownvalue.StringExact("fake-string")),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("terraform_data.test", tfjsonpath.New("input"), knownvalue.StringExact("fake-string")),
+				},
+				Check: func(state *terraform.State) error {
+					resultContent, err := os.ReadFile(f)
+					if err != nil {
+						return fmt.Errorf("Error occurred while reading file at path: %s\n, error: %s\n", f, err)
+					}
+
+					if string(resultContent) != content {
+						return fmt.Errorf("Expected file content %s\n, got: %s\n", content, resultContent)
+					}
+					return nil
+				},
+			},
+			// Test that changing the action configuration by itself doesn't invoke the action
+			{
+				Config: fmt.Sprintf(`
+				resource "terraform_data" "test" {
+					input = "fake-string"
+
+					lifecycle {
+						action_trigger {
+						  events  = [before_create]
+						  actions = [action.framework_unlinked_action.file]
+						}
+					}
+				}
+
+				action "framework_unlinked_action" "file" {
+					config {
+						filename = %[1]q
+						content  = "updated test data"
+					}
+				  
+				}`, f),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("terraform_data.test", plancheck.ResourceActionNoop),
+						plancheck.ExpectKnownValue("terraform_data.test", tfjsonpath.New("input"), knownvalue.StringExact("fake-string")),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("terraform_data.test", tfjsonpath.New("input"), knownvalue.StringExact("fake-string")),
+				},
+				Check: func(state *terraform.State) error {
+					resultContent, err := os.ReadFile(f)
+					if err != nil {
+						return fmt.Errorf("Error occurred while reading file at path: %s\n, error: %s\n", f, err)
+					}
+
+					if string(resultContent) != content {
+						return fmt.Errorf("Expected file content %s\n, got: %s\n", content, resultContent)
+					}
+					return nil
+				},
+			},
+			// test an 'after_update' event
+			{
+				Config: fmt.Sprintf(`
+				resource "terraform_data" "test" {
+					input = "updated-fake-string" # trigger an update
+			
+					lifecycle {
+						action_trigger {
+						  events  = [after_update] # action triggers after update
+						  actions = [action.framework_unlinked_action.file]
+						}
+					}
+				}
+
+				action "framework_unlinked_action" "file" {
+					config {
+						filename = %[1]q
+						content  = "updated test data"
+					}
+				  
+				}`, f),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("terraform_data.test", plancheck.ResourceActionUpdate),
+						plancheck.ExpectKnownValue("terraform_data.test", tfjsonpath.New("input"), knownvalue.StringExact("updated-fake-string")),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("terraform_data.test", tfjsonpath.New("input"), knownvalue.StringExact("updated-fake-string")),
+				},
+				Check: func(state *terraform.State) error {
+					resultContent, err := os.ReadFile(f)
+					if err != nil {
+						return fmt.Errorf("Error occurred while reading file at path: %s\n, error: %s\n", f, err)
+					}
+
+					if string(resultContent) != updatedContent {
+						return fmt.Errorf("Expected file content %s\n, got: %s\n", updatedContent, resultContent)
+					}
+					return nil
+				},
+			},
+			// Test Plan Modification
+			{
+				Config: fmt.Sprintf(`
+				resource "terraform_data" "test" {
+					input = "fake-strings" # trigger an update
+			
+					lifecycle {
+						action_trigger {
+						  events  = [after_update]
+						  actions = [action.framework_unlinked_action.file]
+						}
+					}
+				}
+			
+				action "framework_unlinked_action" "file" {
+					config {
+						filename = %[1]q
+						content  = %[2]q
+						plan_error = true
+					}
+			
+				}`, f, content),
+				ExpectError: regexp.MustCompile("ModifyPlan error"),
+				// Assert that the file remains unchanged
+				Check: func(state *terraform.State) error {
+					resultContent, err := os.ReadFile(f)
+					if err != nil {
+						return fmt.Errorf("Error occurred while reading file at path: %s\n, error: %s\n", f, err)
+					}
+
+					if string(resultContent) != updatedContent {
+						return fmt.Errorf("Expected file content %s\n, got: %s\n", updatedContent, resultContent)
+					}
+					return nil
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Description

Initial framework testing for unlinked actions including basic functionality and plan modifier testing. Currently, Terraform Core doesn't have validation implemented for actions, so validator testing will come in a follow up PR.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
N/A